### PR TITLE
feat: 상세페이지 리팩토링

### DIFF
--- a/src/app/@modal/(.)detail/[id]/view/page.tsx
+++ b/src/app/@modal/(.)detail/[id]/view/page.tsx
@@ -1,3 +1,6 @@
+import ContentsSection from "@/app/detail/_components/ContentsSection";
+import LikeSection from "@/app/detail/_components/LikeSection";
+import ViewCounter from "@/app/detail/_components/ViewCounter";
 import { fetchPostDetail } from "@/lib/utils/post/fetchPostDetail";
 import ModalBg from "./ModalBg";
 import ModalButton from "./ModalButton";
@@ -26,30 +29,15 @@ const DetailModal = async ({ params }: Props) => {
   return (
     <ModalBg>
       <div className="relative w-[400px] rounded-lg bg-white p-6 shadow-lg">
-        <h1 className="mb-4 text-xl font-bold">{post.title}</h1>
-        <p className="mb-2 text-gray-600">작성일: {new Date(post.created_at || "").toLocaleDateString()}</p>
-        <p className="mb-4 text-gray-500">작성자 ID: {post.user_id}</p>
-        <img
-          src={post.thumbnail || "/placeholder.png"}
-          alt={post.title}
-          className="mb-4 h-40 w-full rounded-lg object-cover"
-        />
-        <p className="text-sm text-gray-700">{post.content.slice(0, 100)}...</p>
-        <div className="mt-6">
-          <p>
-            <strong>태그:</strong> {post.tags?.join(", ")}
-          </p>
-          <p>
-            <strong>키:</strong> {post.body_size?.[0]} cm, <strong>몸무게:</strong> {post.body_size?.[1]} kg
-          </p>
-          <p>
-            <strong>조회수:</strong> {post.view} | <strong>좋아요:</strong> {post.likes} | <strong>북마크:</strong>{" "}
-            {post.bookmarks}
-          </p>
+        <ViewCounter postId={postId} />
 
-          <ModalButton label="전체 보기" action="refresh" />
-          <ModalButton label="닫기" action="close" />
+        <ContentsSection postId={postId} />
+        <div className="mt-4 flex gap-4">
+          <LikeSection postId={postId} />
         </div>
+
+        <ModalButton label="전체 보기" action="refresh" />
+        <ModalButton label="닫기" action="close" />
       </div>
     </ModalBg>
   );

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,4 +1,6 @@
+import sampleImage from "@/assets/images/image_sample.png";
 import { fetchPostDetail } from "@/lib/utils/post/fetchPostDetail";
+import Image from "next/image";
 import CommentSection from "../_components/CommentSection";
 import LikeSection from "../_components/LikeSection";
 
@@ -19,8 +21,18 @@ const DetailPage = async ({ params }: Props) => {
   return (
     <div className="mx-auto max-w-3xl p-4">
       <h1 className="text-3xl mb-4 font-bold">{post.title}</h1>
+      <div className="flex items-center gap-4">
+        <div className="relative h-[40px] w-[40px] items-center overflow-hidden rounded-full border-2 bg-gray-100">
+          <Image
+            src={post.users.profile_image || sampleImage}
+            alt={`${post.users.nickname}의 프로필 이미지`}
+            fill={true}
+            className="h-8 w-8 rounded-full"
+          />
+        </div>
+        <p>{post.users.nickname}</p>
+      </div>
       <p className="mb-2 text-gray-600">작성일: {new Date(post.created_at || "").toLocaleDateString()}</p>
-      <p className="mb-4">작성자 ID: {post.user_id}</p>
       <img
         src={post.thumbnail || "/placeholder.png"}
         alt={post.title}

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,8 +1,7 @@
-import sampleImage from "@/assets/images/image_sample.png";
-import { fetchPostDetail } from "@/lib/utils/post/fetchPostDetail";
-import Image from "next/image";
 import CommentSection from "../_components/CommentSection";
+import ContentsSection from "../_components/ContentsSection";
 import LikeSection from "../_components/LikeSection";
+import ViewCounter from "../_components/ViewCounter";
 
 type Props = {
   params: {
@@ -12,51 +11,18 @@ type Props = {
 
 const DetailPage = async ({ params }: Props) => {
   const postId = params.id;
-  const post = await fetchPostDetail(postId);
-
-  if (!post) {
-    return <div>게시글을 찾을 수 없습니다.</div>;
-  }
 
   return (
     <div className="mx-auto max-w-3xl p-4">
-      <h1 className="text-3xl mb-4 font-bold">{post.title}</h1>
-      <div className="flex items-center gap-4">
-        <div className="relative h-[40px] w-[40px] items-center overflow-hidden rounded-full border-2 bg-gray-100">
-          <Image
-            src={post.users.profile_image || sampleImage}
-            alt={`${post.users.nickname}의 프로필 이미지`}
-            fill={true}
-            className="h-8 w-8 rounded-full"
-          />
-        </div>
-        <p>{post.users.nickname}</p>
-      </div>
-      <p className="mb-2 text-gray-600">작성일: {new Date(post.created_at || "").toLocaleDateString()}</p>
-      <img
-        src={post.thumbnail || "/placeholder.png"}
-        alt={post.title}
-        className="mb-4 h-64 w-full rounded-lg object-cover"
-      />
-      <p className="text-lg leading-relaxed">{post.content}</p>
-      <div className="mt-6">
-        <p>
-          <strong>태그:</strong> {post.tags?.join(", ")}
-        </p>
-        <p>
-          <strong>키:</strong> {post.body_size?.[0]} cm, <strong>몸무게:</strong> {post.body_size?.[1]} kg
-        </p>
-        <p>
-          <strong>조회수:</strong> {post.view}
-        </p>
+      <ViewCounter postId={postId} />
 
-        <div className="mt-4 flex gap-4">
-          <LikeSection postId={post.id} />
-        </div>
+      <ContentsSection postId={postId} />
+      <div className="mt-4 flex gap-4">
+        <LikeSection postId={postId} />
       </div>
 
       <div className="mt-4">
-        <CommentSection postId={post.id} />
+        <CommentSection postId={postId} />
       </div>
     </div>
   );

--- a/src/app/detail/_components/CommentSection.tsx
+++ b/src/app/detail/_components/CommentSection.tsx
@@ -14,7 +14,7 @@ const CommentSection = ({ postId }: CommentSectionProps) => {
   const { comments, isPending, addComment, deleteComment } = useComment(postId);
 
   if (isPending) {
-    return <p>댓글을 불러오는 중...</p>;
+    return <p>스켈레톤 ui 추가해야겠지?</p>;
   }
 
   return (

--- a/src/app/detail/_components/CommentSection.tsx
+++ b/src/app/detail/_components/CommentSection.tsx
@@ -19,7 +19,7 @@ const CommentSection = ({ postId }: CommentSectionProps) => {
 
   return (
     <div className="mt-6">
-      <h2 className="text-xl mb-4 font-bold">댓글</h2>
+      <p className="text-xl mb-4 font-bold">댓글 {comments.length}개</p>
       <div className="mb-4 flex justify-between">
         <textarea
           value={comment}
@@ -43,7 +43,7 @@ const CommentSection = ({ postId }: CommentSectionProps) => {
       <ul>
         {comments?.map((comment) => (
           <li key={comment.id} className="mb-4 flex items-center gap-5 border-b pb-4">
-            <div className="relative h-[60px] w-[60px] overflow-hidden rounded-full">
+            <div className="relative h-[50px] w-[50px] overflow-hidden rounded-full">
               <Image src={comment.users.profile_image || sampleImage} alt={comment.users.nickname} fill={true} />
             </div>
             <div className="w-[calc(100%-80px)]">

--- a/src/app/detail/_components/ContentsSection.tsx
+++ b/src/app/detail/_components/ContentsSection.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { usePostDetail } from "@/lib/hooks/detail/usePostDetail";
+import Image from "next/image";
+
+type Props = {
+  postId: string;
+};
+
+const ContentsSection = ({ postId }: Props) => {
+  const { post, isPending, error } = usePostDetail(postId);
+
+  if (isPending) return <div>스켈레톤 ui 추가해야겠지?</div>;
+  if (error) return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
+
+  if (!post) {
+    return <div>게시물을 찾을 수 없습니다.</div>;
+  }
+
+  const { title, users, created_at, thumbnail, content, tags = [], body_size = [], view } = post!;
+
+  return (
+    <div className="contents-section">
+      <p className="text-3xl mb-4 font-bold">{title}</p>
+
+      <div className="mb-4 flex items-center gap-4">
+        <div className="relative h-10 w-10 overflow-hidden rounded-full border-2 bg-gray-100">
+          <Image
+            src={users?.profile_image || "/placeholder-profile.png"}
+            alt={`${users?.nickname || "익명"}의 프로필 이미지`}
+            fill
+            className="object-cover"
+          />
+        </div>
+        <p className="text-lg font-medium">{users?.nickname || "익명"}</p>
+      </div>
+
+      <p className="text-sm mb-2 text-gray-600">
+        작성일: {created_at ? new Date(created_at).toLocaleDateString() : "알 수 없음"}
+      </p>
+
+      <div className="mb-4">
+        <Image
+          src={thumbnail || "/placeholder.png"}
+          alt={title || "게시글 이미지"}
+          width={800}
+          height={400}
+          className="h-64 w-full rounded-lg object-cover"
+        />
+      </div>
+
+      <p className="text-lg mb-6 leading-relaxed">{content}</p>
+
+      <div className="text-sm mt-6 space-y-2 text-gray-800">
+        {tags.length > 0 && (
+          <p>
+            <strong>태그:</strong> {tags.join(", ")}
+          </p>
+        )}
+        {body_size.length === 2 && (
+          <p>
+            <strong>키:</strong> {body_size[0]} cm, <strong>몸무게:</strong> {body_size[1]} kg
+          </p>
+        )}
+        <p>
+          <strong>조회수:</strong> {view}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ContentsSection;

--- a/src/app/detail/_components/LikeSection.tsx
+++ b/src/app/detail/_components/LikeSection.tsx
@@ -37,7 +37,7 @@ const LikeSection = ({ postId }: LikeSectionProps) => {
   }
 
   if (likePending || bookmarkPending) {
-    return <p>로딩 중...</p>;
+    return <p>스켈레톤 ui 추가해야겠지?</p>;
   }
 
   return (

--- a/src/app/detail/_components/ViewCounter.tsx
+++ b/src/app/detail/_components/ViewCounter.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { incrementViewCount } from "@/lib/utils/detail/incrementViewCount";
+import { useEffect } from "react";
+
+type ViewCounterProps = {
+  postId: string;
+};
+
+const ViewCounter = ({ postId }: ViewCounterProps) => {
+  useEffect(() => {
+    incrementViewCount(postId).catch((err) => console.error("조회수 증가 실패:", err));
+  }, [postId]);
+
+  return null;
+};
+
+export default ViewCounter;

--- a/src/app/home/_components/ListLayout.tsx
+++ b/src/app/home/_components/ListLayout.tsx
@@ -20,6 +20,17 @@ const ListLayout = ({ posts }: ListLayoutProps) => {
               <Image src={item.thumbnail || sampleImage} alt={item.title} width={150} height={150} />
             </figure>
             <div>
+              <div className="flex items-center gap-4">
+                <div className="relative h-[40px] w-[40px] items-center overflow-hidden rounded-full border-2 bg-gray-100">
+                  <Image
+                    src={item.users.profile_image || sampleImage}
+                    alt={`${item.users.nickname}의 프로필 이미지`}
+                    fill={true}
+                    className="h-8 w-8 rounded-full"
+                  />
+                </div>
+                <p>{item.users.nickname}</p>
+              </div>
               <p>{item.title}</p>
               <p>{item.tags?.join("")}</p>
             </div>

--- a/src/app/home/_components/MasonryLayout.tsx
+++ b/src/app/home/_components/MasonryLayout.tsx
@@ -21,6 +21,17 @@ const MasonryLayout = ({ posts }: MasonryLayoutProps) => {
               <Image src={item.thumbnail || sampleImage} alt={item.title} width={500} height={500} />
             </figure>
             <div className="click-box bg-black p-4 text-white opacity-0 transition-all duration-300 group-hover:bg-opacity-50 group-hover:opacity-100">
+              <div className="flex items-center gap-4">
+                <div className="relative h-[40px] w-[40px] items-center overflow-hidden rounded-full bg-gray-300">
+                  <Image
+                    src={item.users.profile_image || sampleImage}
+                    alt={`${item.users.nickname}의 프로필 이미지`}
+                    fill={true}
+                    className="h-8 w-8 rounded-full"
+                  />
+                </div>
+                <p>{item.users.nickname}</p>
+              </div>
               <p>{item.title}</p>
               <p>
                 <span>조회수: {item.view}</span>

--- a/src/lib/hooks/detail/useBookmark.ts
+++ b/src/lib/hooks/detail/useBookmark.ts
@@ -7,7 +7,6 @@ type BookmarkState = {
 
 export const useBookmarks = (postId: string, userId?: string) => {
   const queryClient = useQueryClient();
-
   const queryKey = ["bookmarks", postId, userId];
 
   // 북마크 상태 가져오기
@@ -21,7 +20,7 @@ export const useBookmarks = (postId: string, userId?: string) => {
     staleTime: 300000
   });
 
-  // 북마크 토글
+  // 상태에 따라 북마크 토글
   const mutation = useMutation({
     mutationFn: async (isBookmarked: boolean) => {
       if (isBookmarked) {
@@ -35,6 +34,7 @@ export const useBookmarks = (postId: string, userId?: string) => {
 
       const prevState = queryClient.getQueryData<BookmarkState>(queryKey);
 
+      // 낙관적 업데이트
       queryClient.setQueryData(queryKey, (prevState: BookmarkState | undefined) => ({
         ...(prevState || { isBookmarked: false }),
         isBookmarked: !isBookmarked

--- a/src/lib/hooks/detail/useComment.ts
+++ b/src/lib/hooks/detail/useComment.ts
@@ -8,7 +8,7 @@ export const useComment = (postId: string) => {
   const { data: comments = [], isPending } = useQuery({
     queryKey: ["comments", postId],
     queryFn: () => fetchComments(postId),
-    staleTime: 300000 // 캐싱 시간
+    staleTime: 10000
   });
 
   // 댓글 추가

--- a/src/lib/hooks/detail/useComment.ts
+++ b/src/lib/hooks/detail/useComment.ts
@@ -21,7 +21,7 @@ export const useComment = (postId: string) => {
 
   // 댓글 삭제
   const deleteCommentMutation = useMutation({
-    mutationFn: (commentId: string) => deleteComment(commentId, postId),
+    mutationFn: (commentId: string) => deleteComment(commentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", postId] });
     }

--- a/src/lib/hooks/detail/useComment.ts
+++ b/src/lib/hooks/detail/useComment.ts
@@ -21,7 +21,7 @@ export const useComment = (postId: string) => {
 
   // 댓글 삭제
   const deleteCommentMutation = useMutation({
-    mutationFn: (commentId: string) => deleteComment(commentId),
+    mutationFn: (commentId: string) => deleteComment(commentId, postId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", postId] });
     }

--- a/src/lib/hooks/detail/useLike.ts
+++ b/src/lib/hooks/detail/useLike.ts
@@ -5,6 +5,7 @@ export const useLike = (postId: string, userId: string) => {
   const queryClient = useQueryClient();
   const queryKey = ["likes", postId, userId];
 
+  // 좋아요 상태, 총 좋아요 수 가져오기
   const { data: likeData, isPending } = useQuery({
     queryKey,
     queryFn: async () => {
@@ -16,6 +17,7 @@ export const useLike = (postId: string, userId: string) => {
     staleTime: 300000
   });
 
+  // 상태에 따라 좋아요 토글
   const mutation = useMutation({
     mutationFn: (isLiked: boolean) =>
       isLiked ? removeLike(userId, postId) : addLike({ user_id: userId, post_id: postId }),
@@ -24,6 +26,7 @@ export const useLike = (postId: string, userId: string) => {
 
       const prevData = queryClient.getQueryData<{ isLiked: boolean; likeCount: number } | undefined>(queryKey);
 
+      // 낙관적 업데이트
       queryClient.setQueryData(queryKey, {
         isLiked: !isLiked,
         likeCount: isLiked ? (prevData?.likeCount || 0) - 1 : (prevData?.likeCount || 0) + 1
@@ -31,6 +34,7 @@ export const useLike = (postId: string, userId: string) => {
 
       return { prevData };
     },
+    // 에러 시 이전으로 복구
     onError: (_err, _variables, context) => {
       queryClient.setQueryData(queryKey, context?.prevData);
     },

--- a/src/lib/hooks/detail/usePostDetail.ts
+++ b/src/lib/hooks/detail/usePostDetail.ts
@@ -1,0 +1,19 @@
+import type { PostType } from "@/lib/types/post";
+import { fetchPostDetail } from "@/lib/utils/post/fetchPostDetail";
+import { useQuery } from "@tanstack/react-query";
+
+export const usePostDetail = (postId: string, initialPost?: PostType) => {
+  const { data, isPending, error } = useQuery({
+    queryKey: ["postDetail", postId],
+    queryFn: () => fetchPostDetail(postId),
+    initialData: initialPost,
+    staleTime: 3000,
+    enabled: Boolean(postId)
+  });
+
+  return {
+    post: data,
+    isPending,
+    error
+  };
+};

--- a/src/lib/types/post.ts
+++ b/src/lib/types/post.ts
@@ -1,6 +1,8 @@
 import type { Database } from "./supabase";
 
-export type PostType = Database["public"]["Tables"]["posts"]["Row"];
+export type PostType = Database["public"]["Tables"]["posts"]["Row"] & {
+  users: { nickname: string; profile_image?: string | null };
+};
 
 export type FetchPostsResponse = {
   items: PostType[];

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -277,7 +277,6 @@ export type Database = {
       posts: {
         Row: {
           body_size: number[]
-          bookmarks: number
           comments: number
           content: string
           created_at: string
@@ -292,7 +291,6 @@ export type Database = {
         }
         Insert: {
           body_size: number[]
-          bookmarks: number
           comments: number
           content: string
           created_at?: string
@@ -307,7 +305,6 @@ export type Database = {
         }
         Update: {
           body_size?: number[]
-          bookmarks?: number
           comments?: number
           content?: string
           created_at?: string
@@ -395,12 +392,6 @@ export type Database = {
     }
     Functions: {
       increment_view: {
-        Args: {
-          post_id: string
-        }
-        Returns: undefined
-      }
-      sync_comment_count: {
         Args: {
           post_id: string
         }

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -137,7 +137,7 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "chat_messages_memeber_id_room_id_fkey"
+            foreignKeyName: "chat_messages_member_id_room_id_fkey"
             columns: ["member_id", "room_id"]
             isOneToOne: false
             referencedRelation: "chat_members"
@@ -394,7 +394,18 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      increment_view: {
+        Args: {
+          post_id: string
+        }
+        Returns: undefined
+      }
+      sync_comment_count: {
+        Args: {
+          post_id: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -366,6 +366,7 @@ export type Database = {
         Row: {
           created_at: string
           email: string
+          gender: string
           id: string
           nickname: string
           profile_image: string | null
@@ -373,6 +374,7 @@ export type Database = {
         Insert: {
           created_at?: string
           email: string
+          gender?: string
           id?: string
           nickname: string
           profile_image?: string | null
@@ -380,6 +382,7 @@ export type Database = {
         Update: {
           created_at?: string
           email?: string
+          gender?: string
           id?: string
           nickname?: string
           profile_image?: string | null

--- a/src/lib/utils/detail/comments.ts
+++ b/src/lib/utils/detail/comments.ts
@@ -29,13 +29,6 @@ export const createComment = async (postId: string, content: string) => {
   if (insertError) {
     throw new Error(`댓글 작성 실패: ${insertError.message}`);
   }
-
-  // 댓글 개수 동기화
-  const { error: syncError } = await supabase.rpc("sync_comment_count", { post_id: postId });
-
-  if (syncError) {
-    throw new Error(`댓글 개수 동기화 실패: ${syncError.message}`);
-  }
 };
 
 // 댓글 조회
@@ -60,18 +53,13 @@ export const fetchComments = async (postId: string) => {
   return PostComments;
 };
 
-export const deleteComment = async (commentId: string, postId: string) => {
-  // 댓글 삭제
+// 댓글 삭제
+export const deleteComment = async (commentId: string) => {
+  const supabase = createClient();
+
   const { error: deleteError } = await supabase.from("comments").delete().eq("id", commentId);
 
   if (deleteError) {
     throw new Error(`댓글 삭제 실패: ${deleteError.message}`);
-  }
-
-  // 댓글 개수 동기화
-  const { error: syncError } = await supabase.rpc("sync_comment_count", { post_id: postId });
-
-  if (syncError) {
-    throw new Error(`댓글 개수 동기화 실패: ${syncError.message}`);
   }
 };

--- a/src/lib/utils/detail/incrementViewCount.ts
+++ b/src/lib/utils/detail/incrementViewCount.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@/lib/utils/supabase/client";
+
+const supabase = createClient();
+
+export const incrementViewCount = async (postId: string) => {
+  const { error } = await supabase.rpc("increment_view", { post_id: postId });
+
+  if (error) {
+    throw new Error(`조회수 증가 실패: ${error.message}`);
+  }
+};

--- a/src/lib/utils/post/fetchPost.ts
+++ b/src/lib/utils/post/fetchPost.ts
@@ -10,7 +10,15 @@ export const fetchPosts = async ({ pageParam = 1 }): Promise<FetchPostsResponse>
 
   const { data: postsData, error } = await supabase
     .from("posts")
-    .select("*")
+    .select(
+      `
+      *,
+      users (
+        nickname,
+        profile_image
+      )
+    `
+    )
     .order("created_at", { ascending: false })
     .range(from, to);
 

--- a/src/lib/utils/post/fetchPostDetail.ts
+++ b/src/lib/utils/post/fetchPostDetail.ts
@@ -4,7 +4,19 @@ import { createClient } from "@/lib/utils/supabase/client";
 export const fetchPostDetail = async (postId: string): Promise<PostType | null> => {
   const supabase = await createClient();
 
-  const { data: postDetailData, error } = await supabase.from("posts").select("*").eq("id", postId).single();
+  const { data: postDetailData, error } = await supabase
+    .from("posts")
+    .select(
+      `
+      *,
+      users (
+        nickname,
+        profile_image
+      )
+    `
+    )
+    .eq("id", postId)
+    .single();
 
   if (error) {
     console.error("Failed to fetch post:", error.message);


### PR DESCRIPTION
## Title

- 상세페이지 리팩토링

## Changes

- src/app/detail/[id]/page.tsx
- src/app/detail/_components/CommentSection.tsx
- src/app/detail/_components/ContentsSection.tsx
- src/app/detail/_components/ViewCounter.tsx
- src/lib/hooks/detail/usePostDetail.ts
- src/lib/utils/detail/incrementViewCount.ts

## PR 생성 날짜

- 2025.01.12

## CheckList

- 작성자 이름, 프로필사진 추가
- 조회수 업데이트 반영
- posts 테이블 comments 컬럼에 게시글 댓글 개수 동기화
- 상세페이지 서버액션 페칭이 불필요해 제거, 컴포넌트 분리하여 클라이언트 페칭으로 변경
