### PR TITLE
feat: 페이지간 이동을 위한 임시 헤더 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@phosphor-icons/react": "^2.1.7",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.10",
     "@tanstack/react-query": "^5.62.11",

--- a/src/app/(auth)/_components/AuthInput.tsx
+++ b/src/app/(auth)/_components/AuthInput.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { HTMLInputTypeAttribute } from "react";
 import type { FieldValues, Path, UseFormRegister } from "react-hook-form";
 
 type InputProps<T extends FieldValues> = {
   id: Path<T>;
-  type: string;
+  type: HTMLInputTypeAttribute;
   placeholder: string;
   register: UseFormRegister<T>;
   error?: string;

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
       // 소셜 로그인 한정
       // 유저 정보 public에 저장
       const { data } = await supabase.auth.getUser();
-      
+
       const email = data.user?.email as string;
       const id = data.user?.id as string;
       const nickname = data.user?.user_metadata.full_name as string;

--- a/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/src/app/(auth)/login/_components/LoginForm.tsx
@@ -28,7 +28,7 @@ const LoginForm = () => {
   return (
     <>
       <form className="flex w-full flex-col" autoComplete="off" onSubmit={handleSubmit(handleLogin)}>
-        {LOGIN_FIELDS.map((field, index) => (
+        {LOGIN_FIELDS.map((field) => (
           <AuthInput
             key={field.id}
             id={field.id}

--- a/src/app/(auth)/login/_components/LoginOptions.tsx
+++ b/src/app/(auth)/login/_components/LoginOptions.tsx
@@ -17,10 +17,10 @@ const LoginOptions = () => {
       {!isEmailLogin ? (
         <>
           <button
-            className="flex w-full flex-row justify-center gap-4 mt-8 rounded-2xl bg-white p-4 text-black shadow-md"
+            className="mt-8 flex w-full flex-row justify-center gap-4 rounded-2xl bg-white p-4 text-black shadow-md"
             onClick={showEmailForm}
           >
-            <Image src="/images/default-user-profile.png" width={25} height={25} alt="FitFor login" priority/>
+            <Image src="/images/default-user-profile.png" width={25} height={25} alt="FitFor login" priority />
             <span>이메일로 시작</span>
           </button>
           <SocialLoginButton provider="google" />
@@ -28,7 +28,9 @@ const LoginOptions = () => {
         </>
       ) : (
         <>
-          <button onClick={showEmailForm} className="self-start text-gray-500 hover:text-black">{'<- '}뒤로가기</button>
+          <button onClick={showEmailForm} className="self-start text-gray-500 hover:text-black">
+            {"<- "}뒤로가기
+          </button>
           <LoginForm />
         </>
       )}

--- a/src/app/(auth)/login/_components/SocialLoginButton.tsx
+++ b/src/app/(auth)/login/_components/SocialLoginButton.tsx
@@ -17,14 +17,9 @@ const SocialLoginButton = ({ provider }: SocialLoginButtonProps) => {
   return (
     <button
       onClick={handleSocialLogin}
-      className={`flex flex-row gap-4 rounded-2xl p-4 w-full justify-center ${PROVIDER_CONFIG[provider].bgColor} ${PROVIDER_CONFIG[provider].textColor} shadow-md`}
+      className={`flex w-full flex-row justify-center gap-4 rounded-2xl p-4 ${PROVIDER_CONFIG[provider].bgColor} ${PROVIDER_CONFIG[provider].textColor} shadow-md`}
     >
-      <Image
-        src={PROVIDER_CONFIG[provider].logo}
-        width={24}
-        height={24}
-        alt={`${provider}Logo`}
-      />
+      <Image src={PROVIDER_CONFIG[provider].logo} width={24} height={24} alt={`${provider}Logo`} />
       <span>{PROVIDER_CONFIG[provider].label}</span>
     </button>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@ import LoginOptions from "./_components/LoginOptions";
 const LoginPage = () => {
   return (
     <div className="h-screen w-full justify-items-center p-8">
-      <div className="w-1/4 flex flex-col items-center">
+      <div className="flex w-1/4 flex-col items-center">
         <h1 className="self-start text-heading font-bold">로그인</h1>
         <LoginOptions />
       </div>

--- a/src/app/(auth)/signup/_components/RegistrationForm.tsx
+++ b/src/app/(auth)/signup/_components/RegistrationForm.tsx
@@ -1,11 +1,11 @@
 "use client";
+import { signup } from "@/lib/utils/auth/auth";
 import { SIGNUP_FIELDS } from "@/lib/validataions/authFields";
 import { signupSchema } from "@/lib/validataions/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useForm, type FieldValues } from "react-hook-form";
 import AuthInput from "../../_components/AuthInput";
-import { signup } from "@/lib/utils/auth/auth";
 
 const RegistrationForm = () => {
   const { register, handleSubmit, formState } = useForm({
@@ -29,7 +29,7 @@ const RegistrationForm = () => {
   return (
     <>
       <form className="mt-8 flex w-full flex-col" autoComplete="off" onSubmit={handleSubmit(handleSignup)}>
-        {SIGNUP_FIELDS.map((field, index) => (
+        {SIGNUP_FIELDS.map((field) => (
           <AuthInput
             key={field.id}
             id={field.id}
@@ -39,7 +39,7 @@ const RegistrationForm = () => {
             error={formState.errors[field.id]?.message}
           />
         ))}
-        {formState.errors.root && (<span>{formState.errors.root.message}</span>)}
+        {formState.errors.root && <span>{formState.errors.root.message}</span>}
         <button
           type="submit"
           className="flex w-full flex-row justify-center gap-4 rounded-2xl bg-[#FF3365] p-4 font-bold disabled:bg-[#FFD6E0]"

--- a/src/app/(auth)/signup/_components/RegistrationStep.tsx
+++ b/src/app/(auth)/signup/_components/RegistrationStep.tsx
@@ -1,9 +1,5 @@
-import React from 'react'
-
 const RegistrationStep = () => {
-  return (
-    <div>RegistrationStep</div>
-  )
-}
+  return <div>RegistrationStep</div>;
+};
 
-export default RegistrationStep
+export default RegistrationStep;

--- a/src/app/mypage/_components/ProfileSection.tsx
+++ b/src/app/mypage/_components/ProfileSection.tsx
@@ -28,7 +28,7 @@ const ProfileSection = () => {
         <p className="text-2xl">
           <strong>{user!.nickname}</strong>
         </p>
-        <p className="flex flex-col text-base">
+        <p className="text-base flex flex-col">
           <strong> [유저 디테일 들어가는 자리]</strong>
         </p>
         <button className="max-w-40 rounded-2xl bg-black px-4 py-2 text-white">프로필 수정(x)</button>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,6 +8,6 @@ const PrivatePage = () => {
       <SignoutButton />
     </div>
   );
-}
+};
 
 export default PrivatePage;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,9 +2,9 @@ import HeaderContent from "./HeaderContent";
 
 const Header = () => {
   return (
-    <div className="w-full bg-white p-8 flex justify-center">
+    <header className="w-full bg-white p-8 flex justify-center shadow-md">
       <HeaderContent />
-    </div>
+    </header>
   );
 };
 

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -1,11 +1,62 @@
 "use client";
 
 import { useUser } from "@/lib/hooks/auth/useUser";
+import { useAuthStore } from "@/lib/store/authStore";
+import { MagnifyingGlass } from "@phosphor-icons/react";
+import Image from "next/image";
+import Link from "next/link";
 
 const HeaderContent = () => {
   useUser();
+  const { user } = useAuthStore();
 
-  return <p>HeaderContent</p>;
+  return (
+    <div className="container mx-auto flex h-full max-w-[1200px] items-center justify-between">
+      <div className="flex items-center gap-4">
+        {/* Logo */}
+        <div className="flex h-12 w-32 items-center justify-center rounded-2xl border-2 border-black">
+          <Link href="/" className="font-bold">
+            FITFOR
+          </Link>
+        </div>
+
+        {/* 라이브 버튼 */}
+        <div className="h-[50px] w-[50px] rounded-full bg-black text-white" />
+      </div>
+
+      {/* 검색창 */}
+      <div className="max-w-xl flex-1 items-center justify-center">
+        <div className="flex w-full max-w-lg flex-row items-center gap-4 rounded-xl bg-gray-300 pr-4">
+          <input
+            type="search"
+            placeholder="검색"
+            className="h-12 w-full rounded-l-2xl bg-transparent pl-4 text-black placeholder:text-black focus-visible:outline-gray-400"
+          />
+          <button>
+            <MagnifyingGlass size={30} className="text-black" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="h-[50px] w-[50px] rounded-full bg-black text-white" />
+        {user ? (
+          <Link href="/mypage">
+            <Image
+              src={user!.profile_image as string}
+              alt={`${user.nickname}'s profile`}
+              width={50}
+              height={50}
+              priority
+              className="rounded-full"
+            />
+          </Link>
+        ) : (
+          <Link href="/login">로그인</Link>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default HeaderContent;

--- a/src/lib/styles/globals.css
+++ b/src/lib/styles/globals.css
@@ -7,3 +7,19 @@
     @apply absolute left-0 top-0 block h-full w-full;
   }
 }
+
+/* input type=search x button 제거 */
+/* WebKit browsers */
+input[type="search"]::-webkit-search-cancel-button {
+  display: none;
+}
+
+/* Firefox */
+input[type="search"]::-moz-search-cancel-button {
+  display: none;
+}
+
+/* Edge */
+input[type="search"]::-ms-clear {
+  display: none;
+}

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -1,6 +1,7 @@
 import googleLogo from "@/assets/images/google-logo.svg";
 import kakaoLogo from "@/assets/images/kakao-logo.svg";
 import { Database } from "./supabase";
+import type { HTMLInputTypeAttribute } from "react";
 
 export type User = Database["public"]["Tables"]["users"]["Row"];
 
@@ -36,7 +37,7 @@ export const PROVIDER_CONFIG: Record<Provider, ProviderConfig> = {
 export type FormField<T> = {
   id: keyof T;
   label: string;
-  type: string;
+  type: HTMLInputTypeAttribute;
   placeholder: string;
   validation?: object;
 };

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -137,7 +137,7 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "chat_messages_memeber_id_room_id_fkey"
+            foreignKeyName: "chat_messages_member_id_room_id_fkey"
             columns: ["member_id", "room_id"]
             isOneToOne: false
             referencedRelation: "chat_members"
@@ -394,7 +394,18 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      increment_view: {
+        Args: {
+          post_id: string
+        }
+        Returns: undefined
+      }
+      sync_comment_count: {
+        Args: {
+          post_id: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,11 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@phosphor-icons/react@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/react/-/react-2.1.7.tgz#b11a4b25849b7e3849970b688d9fe91e5d4fd8d7"
+  integrity sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"


### PR DESCRIPTION
## Title

- feat: 페이지간 이동을 위한 임시 헤더 구현

## Changes

- components/layout/Header.tsx
- components/layout/HeaderContent.tsx
- lib/styles/global.css
- phosphoricons 라이브러리 추가

## PR 생성 날짜

- 2025.01.12

## CheckList

- [X] 주석 정리

아이콘스 라이브러리 추가하였습니다, yarn 해주세요!

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/5adf4262-4020-4b8f-a5e9-e5891d07689c" />
