### PR TITLE
feat:  이미지, 다중 파일 업로드 기능 추가 및 최대 이미지 제한 설정

### DIFF
--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -357,7 +357,7 @@ const WritePage = () => {
                         </div>
                       )}
                     </div>
-                    <p className="text-sm font-bold text-center mt-2">
+                    <p className="text-sm font-bold text-center mt-2 truncate w-32">
                       {purchase.title || "상품 상세 정보"}
                     </p>
                   </div>


### PR DESCRIPTION
## Title

- feat:  이미지, 다중 파일 업로드 기능 추가 및 최대 이미지 제한 설정

## Changes

- src/app/write/_components/ThumbnailUpload.tsx
- src/app/write/page.tsx

## PR 생성 날짜

- 2025.1.16

## CheckList

### 현재 구현이 완료된 기능 

- [x] 룩북 업로드 시, 여러 파일을 한 번에 올릴 수 있는 다중 파일 업로드 기능을 추가
- [x] 시안에서 변경된 최대 이미지 업로드 개수, 5개에서 4개로 제한

### 추후 작업 예정 사항

- 임시저장 기능 구현 완료 후, 컴포넌트로 분리공사 진행 예정
- 피드백.. 받았던 대로 코드 수정 (max size 함수 및 타입, 경로 수정 필요)
- 제작된 태그 컴포넌트 활용 예정 (...꼭 할겁니다)

