### PR TITLE
feat: 새벽감성 수정페이지 구현

### DIFF
--- a/src/app/detail/_components/ContentsSection.tsx
+++ b/src/app/detail/_components/ContentsSection.tsx
@@ -51,8 +51,7 @@ const ContentsSection = ({ postId, mode = "page" }: Props) => {
             <p className="text-text-03">{relativeTimeDay(created_at)}</p>
           </div>
 
-          {/* 엄정은이 추가하라고 해서 추가한 줄바꿈.. 기능추가 ^-^)b */}
-          <p className="mt-6 h-[8.5rem] overflow-auto text-title2 font-medium whitespace-pre-wrap">{content}</p>
+          <p className="mt-6 h-[8.5rem] overflow-auto text-title2 font-medium">{content}</p>
 
           {tags.length > 0 && (
             <div className="mt-10 flex flex-wrap gap-2">

--- a/src/app/detail/_components/ContentsSection.tsx
+++ b/src/app/detail/_components/ContentsSection.tsx
@@ -51,7 +51,8 @@ const ContentsSection = ({ postId, mode = "page" }: Props) => {
             <p className="text-text-03">{relativeTimeDay(created_at)}</p>
           </div>
 
-          <p className="mt-6 h-[8.5rem] overflow-auto text-title2 font-medium">{content}</p>
+          {/* 엄정은이 추가하라고 해서 추가한 줄바꿈.. 기능추가 ^-^)b */}
+          <p className="mt-6 h-[8.5rem] overflow-auto text-title2 font-medium whitespace-pre-wrap">{content}</p>
 
           {tags.length > 0 && (
             <div className="mt-10 flex flex-wrap gap-2">

--- a/src/app/write/[id]/page.tsx
+++ b/src/app/write/[id]/page.tsx
@@ -1,4 +1,165 @@
-// 수정페이지 작성
-// 작성 페이지와 동일하게 갈 것, 하지만 수정기능이 필요한 페이지이므로
-// 페이지가 불러와진 상태를 유지할 것.
-//[id]는 posts의 id 사용하면 될듯
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useFormHandlers } from "@/lib/hooks/write/useFormHanlders";
+import { useEditPostQuery, useUpdatePostMutation } from "@/lib/hooks/write/usePostQueries";
+import AddressModal from "../_components/AddressModal";
+import BodySizeSection from "../_components/BodySizeSection";
+import ContentSection from "../_components/ContentSection";
+import ImageUploadSection from "../_components/ImageUploadSection";
+import LocationSection from "../_components/LocationSection";
+import ProductSection from "../_components/ProductSection";
+import PurchaseModal from "../_components/PurchaseModal";
+import TagSection from "../../../components/shared/TagSection";
+import LoadingSpinner from "@/components/shared/LoadingSpinner";
+import { useRef, useEffect } from "react";
+
+type EditPageProps = {
+  params: {
+    id: string; // 명시적으로 string 타입을 선언
+  };
+};
+
+const EditPage = ({ params: { id } }: EditPageProps) => {
+  const router = useRouter();
+
+  // 폼 상태 및 핸들러 초기화
+  const {
+    formState,
+    handleChange,
+    handleAddPurchase,
+    handleEditPurchase,
+    handleDeletePurchase,
+    handleBodySizeChange,
+    toggleTagSelector,
+    handleChangeCategory,
+    tags,
+    selectedCategory,
+    setInitialFormState = () => {},
+  } = useFormHandlers();
+
+  const { data: fetchedData, isPending, isError } = useEditPostQuery(id);
+
+  // 한 번만 실행되도록 플래그 관리
+  const isFormInitialized = useRef(false);
+
+  useEffect(() => {
+    if (fetchedData && !isFormInitialized.current) {
+      // 데이터가 있고, 아직 폼 초기화가 되지 않은 경우에만 실행
+      setInitialFormState({
+        ...fetchedData.post,
+        purchases: fetchedData.purchases,
+      });
+      isFormInitialized.current = true; // 초기화 플래그 설정
+    }
+  }, [fetchedData, setInitialFormState]);
+
+  // 게시물 수정 뮤테이션
+  const mutation = useUpdatePostMutation(id, formState, {
+    onSuccess: () => {
+      alert("수정 성공!");
+      router.push(`/detail/${id}`);
+    },
+    onError: (error) => {
+      console.error("게시물 수정 실패:", error);
+      alert("수정 실패");
+    },
+  });
+  // 수정 완료 버튼 핸들러
+  const handleUpdate = () => {
+    mutation.mutate();
+  };
+
+  if (isPending) return <LoadingSpinner />;
+  if (isError) return <p>게시물을 불러오는 데 문제가 발생했습니다.</p>;
+
+  return (
+    <div className="mx-auto max-w-[700px] pt-10 pb-20">
+      <div className="space-y-2 pb-10">
+        <h1 className="text-title1 font-bold leading-[150%] text-text-04">게시물 수정하기</h1>
+      </div>
+
+      <div className="rounded-2xl border border-line-02 bg-bg-01 px-8 py-9">
+        <ContentSection content={formState.content} onChange={(value) => handleChange("content", value)} />
+
+        <ImageUploadSection
+          images={formState.images}
+          setImages={(images) => handleChange("images", images)}
+          blur={formState.thumbnail_blur_url}
+          setBlur={(blurUrl) => handleChange("thumbnail_blur_url", blurUrl)}
+        />
+
+        <LocationSection
+          address={formState.address}
+          onOpenModal={() => handleChange("isModalOpen", true)}
+        />
+
+        <BodySizeSection
+          bodySize={formState.body_size}
+          onChange={handleBodySizeChange}
+        />
+
+        <ProductSection
+          purchases={formState.purchases}
+          onAdd={() => {
+            if (formState.purchases.length >= 5) {
+              alert("상품은 최대 5개까지만 추가할 수 있습니다.");
+              return;
+            }
+            handleChange("productToEdit", null);
+            handleChange("isPurchaseModalOpen", true);
+          }}
+          onEdit={(index) => {
+            handleChange("productToEdit", formState.purchases[index]);
+            handleChange("isPurchaseModalOpen", true);
+          }}
+          onDelete={handleDeletePurchase}
+        />
+
+        <TagSection
+          title="게시물 주제를 선택해주세요."
+          tags={tags}
+          selectedCategory={selectedCategory}
+          onChangeCategory={handleChangeCategory}
+          toggleTagSelector={toggleTagSelector}
+        />
+      </div>
+
+      <div className="flex justify-center gap-6 pt-20">
+        <button
+          onClick={() => router.push(`/detail/${id}`)}
+          className="rounded-lg border border-primary-default bg-bg-01 px-8 py-4 text-body font-medium text-primary-default"
+        >
+          뒤로 가기
+        </button>
+        <button
+          onClick={handleUpdate}
+          className="rounded-lg bg-primary-default px-8 py-4 text-body font-medium text-bg-01"
+        >
+          수정 완료
+        </button>
+      </div>
+
+      <AddressModal
+        isOpen={formState.isModalOpen}
+        onClose={() => handleChange("isModalOpen", false)}
+        onSelectAddress={(address) => handleChange("address", address)}
+      />
+
+      <PurchaseModal
+        isOpen={formState.isPurchaseModalOpen}
+        onClose={() => {
+          handleChange("productToEdit", null);
+          handleChange("isPurchaseModalOpen", false);
+        }}
+        onAddProduct={handleAddPurchase}
+        onEditProduct={handleEditPurchase}
+        productToEdit={formState.productToEdit}
+        mode={formState.productToEdit ? "edit" : "add"}
+        purchasesLength={formState.purchases.length}
+      />
+    </div>
+  );
+};
+
+export default EditPage;

--- a/src/app/write/[id]/page.tsx
+++ b/src/app/write/[id]/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import LoadingSpinner from "@/components/shared/LoadingSpinner";
 import { useFormHandlers } from "@/lib/hooks/write/useFormHanlders";
 import { useEditPostQuery, useUpdatePostMutation } from "@/lib/hooks/write/usePostQueries";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import TagSection from "../../../components/shared/TagSection";
 import AddressModal from "../_components/AddressModal";
 import BodySizeSection from "../_components/BodySizeSection";
 import ContentSection from "../_components/ContentSection";
@@ -10,9 +13,6 @@ import ImageUploadSection from "../_components/ImageUploadSection";
 import LocationSection from "../_components/LocationSection";
 import ProductSection from "../_components/ProductSection";
 import PurchaseModal from "../_components/PurchaseModal";
-import TagSection from "../../../components/shared/TagSection";
-import LoadingSpinner from "@/components/shared/LoadingSpinner";
-import { useRef, useEffect } from "react";
 
 type EditPageProps = {
   params: {
@@ -34,7 +34,7 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
     toggleTagSelector,
     handleChangeCategory,
     selectedCategory,
-    setInitialFormState = () => {},
+    setInitialFormState = () => {}
   } = useFormHandlers();
 
   const { data: fetchedData, isPending, isError } = useEditPostQuery(id);
@@ -47,7 +47,7 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
       // 데이터가 있고, 아직 폼 초기화가 되지 않은 경우에만 실행
       setInitialFormState({
         ...fetchedData.post,
-        purchases: fetchedData.purchases,
+        purchases: fetchedData.purchases
       });
       isFormInitialized.current = true; // 초기화 플래그 설정
     }
@@ -62,7 +62,7 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
     onError: (error) => {
       console.error("게시물 수정 실패:", error);
       alert("수정 실패");
-    },
+    }
   });
   // 수정 완료 버튼 핸들러
   const handleUpdate = () => {
@@ -73,7 +73,7 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
   if (isError) return <p>게시물을 불러오는 데 문제가 발생했습니다.</p>;
 
   return (
-    <div className="mx-auto max-w-[700px] pt-10 pb-20">
+    <div className="mx-auto max-w-[700px] pb-20 pt-10">
       <div className="space-y-2 pb-10">
         <h1 className="text-title1 font-bold leading-[150%] text-text-04">게시물 수정하기</h1>
       </div>
@@ -88,15 +88,9 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
           setBlur={(blurUrl) => handleChange("thumbnail_blur_url", blurUrl)}
         />
 
-        <LocationSection
-          address={formState.address}
-          onOpenModal={() => handleChange("isModalOpen", true)}
-        />
+        <LocationSection address={formState.address} onOpenModal={() => handleChange("isModalOpen", true)} />
 
-        <BodySizeSection
-          bodySize={formState.body_size}
-          onChange={handleBodySizeChange}
-        />
+        <BodySizeSection bodySize={formState.body_size} onChange={handleBodySizeChange} />
 
         <ProductSection
           purchases={formState.purchases}

--- a/src/app/write/[id]/page.tsx
+++ b/src/app/write/[id]/page.tsx
@@ -33,7 +33,6 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
     handleBodySizeChange,
     toggleTagSelector,
     handleChangeCategory,
-    tags,
     selectedCategory,
     setInitialFormState = () => {},
   } = useFormHandlers();
@@ -118,7 +117,7 @@ const EditPage = ({ params: { id } }: EditPageProps) => {
 
         <TagSection
           title="게시물 주제를 선택해주세요."
-          tags={tags}
+          tags={formState.tags}
           selectedCategory={selectedCategory}
           onChangeCategory={handleChangeCategory}
           toggleTagSelector={toggleTagSelector}

--- a/src/app/write/_components/ContentSection.tsx
+++ b/src/app/write/_components/ContentSection.tsx
@@ -1,3 +1,6 @@
+import { textFieldVariants } from "@/components/ui/TextField";
+import { cn } from "@/lib/utils/common/className";
+
 type ContentSectionProps = {
   content: string;
   onChange: (value: string) => void;
@@ -5,19 +8,24 @@ type ContentSectionProps = {
 
 const ContentSection = ({ content, onChange }: ContentSectionProps) => (
   <div className="space-y-2">
+    {/* 제목 영역 */}
     <div className="flex items-center gap-1">
       <span className="text-title2 font-bold text-text-04">본문</span>
       <span className="text-title2 font-bold text-primary-default">*</span>
     </div>
+    {/* textarea 영역 */}
     <textarea
       value={content}
       onChange={(e) => {
-        onChange(e.target.value);
-        e.target.style.height = "auto";
-        e.target.style.height = `${e.target.scrollHeight}px`;
+        onChange(e.target.value); // 줄바꿈 포함된 텍스트 전달
+        e.target.style.height = "auto"; // 높이 초기화
+        e.target.style.height = `${e.target.scrollHeight}px`; // 동적 높이 계산
       }}
-      rows={6}
-      className="h-38 w-full resize-none rounded-lg bg-bg-02 p-4 text-body font-medium placeholder-text-02 focus:outline-none"
+      rows={5}
+      className={cn(
+        textFieldVariants({ variant: "default", version: "desktop" }), // TextField 스타일 적용
+        "focus-visible:box-shadow-none h-auto w-full resize-none overflow-hidden p-4 text-body font-medium placeholder-text-02 focus:outline-none focus-visible:border-transparent focus-visible:ring-0"
+      )}
       placeholder="예시 - 소개팅 가야하는데 도와주세요"
     />
   </div>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFormHandlers } from "@/lib/hooks/write/useFormHanlders";
+import TagSection from "../../components/shared/TagSection";
 import AddressModal from "./_components/AddressModal";
 import BodySizeSection from "./_components/BodySizeSection";
 import ContentSection from "./_components/ContentSection";
@@ -8,7 +9,6 @@ import ImageUploadSection from "./_components/ImageUploadSection";
 import LocationSection from "./_components/LocationSection";
 import ProductSection from "./_components/ProductSection";
 import PurchaseModal from "./_components/PurchaseModal";
-import TagSection from "../../components/shared/TagSection";
 
 const WritePage = () => {
   const {
@@ -19,11 +19,14 @@ const WritePage = () => {
     handleDeletePurchase,
     handleBodySizeChange,
     handleSubmit,
-    toggleTagSelector
+    toggleTagSelector,
+    handleChangeCategory,
+    tags,
+    selectedCategory
   } = useFormHandlers();
 
   return (
-    <div className="mx-auto max-w-[700px] pt-10 pb-20">
+    <div className="mx-auto max-w-[700px] pb-20 pt-10">
       {/* 어쩔수 없이 pb로 설정.. */}
       <div className="space-y-2 pb-10">
         <h1 className="text-title1 font-bold leading-[150%] text-text-04">게시물 작성하기</h1>
@@ -65,9 +68,9 @@ const WritePage = () => {
 
         <TagSection
           title="게시물 주제를 선택해주세요."
-          tags={formState.tags}
-          selectedCategory={formState.selectedCategory}
-          onChangeCategory={(category) => handleChange("selectedCategory", category)}
+          tags={tags}
+          selectedCategory={selectedCategory}
+          onChangeCategory={handleChangeCategory}
           toggleTagSelector={toggleTagSelector}
         />
       </div>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -21,7 +21,6 @@ const WritePage = () => {
     handleSubmit,
     toggleTagSelector,
     handleChangeCategory,
-    tags,
     selectedCategory
   } = useFormHandlers();
 
@@ -68,7 +67,7 @@ const WritePage = () => {
 
         <TagSection
           title="게시물 주제를 선택해주세요."
-          tags={tags}
+          tags={formState.tags}
           selectedCategory={selectedCategory}
           onChangeCategory={handleChangeCategory}
           toggleTagSelector={toggleTagSelector}

--- a/src/lib/hooks/write/useFormHanlders.ts
+++ b/src/lib/hooks/write/useFormHanlders.ts
@@ -20,7 +20,6 @@ type FormState = {
   isModalOpen: boolean;
   isPurchaseModalOpen: boolean;
   productToEdit: Database["public"]["Tables"]["purchase"]["Insert"] | null;
-  selectedCategory: string | null;
   thumbnail_blur_url: string | null;
 };
 
@@ -36,12 +35,43 @@ export const useFormHandlers = () => {
     isModalOpen: false, // 주소 검색 모달 상태
     isPurchaseModalOpen: false, // 상품 추가 모달 상태
     productToEdit: null, // 수정할 상품 데이터
-    selectedCategory: null,
     thumbnail_blur_url: null
   });
 
+  type PostWithPurchases = Database["public"]["Tables"]["posts"]["Row"] & {
+    purchases: Database["public"]["Tables"]["purchase"]["Row"][];
+  };
+  
+  const setInitialFormState = async (data: PostWithPurchases) => {
+    try {
+      setFormState({
+        address: data.upload_place || "",
+        content: data.content || "",
+        body_size: data.body_size || [],
+        images: data.images || [],
+        tags: data.tags || [],
+        purchases: data.purchases || [], // purchases 포함
+        isModalOpen: false,
+        isPurchaseModalOpen: false,
+        productToEdit: null,
+        thumbnail_blur_url: data.thumbnail_blur_url || null,
+      });
+    } catch (error) {
+      console.error("Error initializing form state:", error);
+    }
+  };
+
   const router = useRouter(); // 페이지 이동 관리
   const currentUser = useAuthStore((state) => state.user); // 현재 사용자 정보 가져오기
+    // 태그 섹션 관련 상태
+    const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+    const [tags, setTags] = useState<string[]>([]);
+  
+    // 카테고리 변경 핸들러
+    const handleChangeCategory = (category: string) => {
+      setSelectedCategory(category);
+      setTags([]); // 카테고리 변경 시 태그 초기화
+    };
 
   // 폼 상태 변경 핸들러
   const handleChange = <T extends keyof FormState>(key: T, value: FormState[T]) => {
@@ -180,6 +210,10 @@ export const useFormHandlers = () => {
     handleDeletePurchase,
     handleBodySizeChange,
     handleSubmit,
-    toggleTagSelector
+    toggleTagSelector,
+    handleChangeCategory,
+    tags,
+    selectedCategory,
+    setInitialFormState
   };
 };

--- a/src/lib/hooks/write/useFormHanlders.ts
+++ b/src/lib/hooks/write/useFormHanlders.ts
@@ -41,7 +41,7 @@ export const useFormHandlers = () => {
   type PostWithPurchases = Database["public"]["Tables"]["posts"]["Row"] & {
     purchases: Database["public"]["Tables"]["purchase"]["Row"][];
   };
-  
+
   const setInitialFormState = async (data: PostWithPurchases) => {
     try {
       setFormState({
@@ -54,7 +54,7 @@ export const useFormHandlers = () => {
         isModalOpen: false,
         isPurchaseModalOpen: false,
         productToEdit: null,
-        thumbnail_blur_url: data.thumbnail_blur_url || null,
+        thumbnail_blur_url: data.thumbnail_blur_url || null
       });
     } catch (error) {
       console.error("Error initializing form state:", error);
@@ -63,15 +63,15 @@ export const useFormHandlers = () => {
 
   const router = useRouter(); // 페이지 이동 관리
   const currentUser = useAuthStore((state) => state.user); // 현재 사용자 정보 가져오기
-    // 태그 섹션 관련 상태
-    const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-    const [tags, setTags] = useState<string[]>([]);
-  
-    // 카테고리 변경 핸들러
-    const handleChangeCategory = (category: string) => {
-      setSelectedCategory(category);
-      setTags([]); // 카테고리 변경 시 태그 초기화
-    };
+  // 태그 섹션 관련 상태
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+
+  // 카테고리 변경 핸들러
+  const handleChangeCategory = (category: string) => {
+    setSelectedCategory(category);
+    setTags([]); // 카테고리 변경 시 태그 초기화
+  };
 
   // 폼 상태 변경 핸들러
   const handleChange = <T extends keyof FormState>(key: T, value: FormState[T]) => {

--- a/src/lib/hooks/write/useFormHanlders.ts
+++ b/src/lib/hooks/write/useFormHanlders.ts
@@ -212,7 +212,6 @@ export const useFormHandlers = () => {
     handleSubmit,
     toggleTagSelector,
     handleChangeCategory,
-    tags,
     selectedCategory,
     setInitialFormState
   };

--- a/src/lib/hooks/write/usePostQueries.ts
+++ b/src/lib/hooks/write/usePostQueries.ts
@@ -1,0 +1,125 @@
+// useEditPostQuery와 useUpdatePostMutation 훅 구현
+
+import { useQuery, useMutation, UseMutationOptions, UseQueryOptions } from "@tanstack/react-query";
+import { createClient } from "@/lib/utils/supabase/client";
+import type { Database } from "@/lib/types/supabase";
+
+const supabase = createClient();
+
+export const useEditPostQuery = (
+  id: string,
+  onSuccess?: (data: {
+    post: Database["public"]["Tables"]["posts"]["Row"];
+    purchases: Database["public"]["Tables"]["purchase"]["Row"][];
+  }) => void
+) => {
+  return useQuery<
+    {
+      post: Database["public"]["Tables"]["posts"]["Row"];
+      purchases: Database["public"]["Tables"]["purchase"]["Row"][];
+    },
+    Error
+  >({
+    queryKey: ["post", id],
+    queryFn: async () => {
+      const { data: postData, error: postError } = await supabase
+        .from("posts")
+        .select("*")
+        .eq("id", id)
+        .single();
+    
+      console.log("Fetched postData:", postData); // 디버깅 로그 추가
+    
+      if (postError) {
+        console.error("Post fetch error:", postError);
+        throw postError;
+      }
+    
+      const { data: purchaseData, error: purchaseError } = await supabase
+        .from("purchase")
+        .select("*")
+        .eq("post_id", id);
+    
+      console.log("Fetched purchaseData:", purchaseData); // 디버깅 로그 추가
+    
+      if (purchaseError) {
+        console.error("Purchase fetch error:", purchaseError);
+        throw purchaseError;
+      }
+    
+      return {
+        post: postData,
+        purchases: purchaseData || [],
+      };
+    },
+    staleTime: 60000, // 1분 동안 캐싱
+    onSuccess, // 옵션 객체의 일부로 포함
+  } as UseQueryOptions<
+    {
+      post: Database["public"]["Tables"]["posts"]["Row"];
+      purchases: Database["public"]["Tables"]["purchase"]["Row"][];
+    },
+    Error
+  >);
+};
+
+export const useUpdatePostMutation = (
+  id: string,
+  formState: {
+    content: string;
+    address: string;
+    body_size: number[];
+    images: string[];
+    tags: string[];
+    purchases: Database["public"]["Tables"]["purchase"]["Insert"][];
+  },
+  options?: UseMutationOptions<void, Error, void> // 타입 명시
+) => {
+  // mutationFn 정의
+  const mutationFn = async (): Promise<void> => {
+    const { content, address, body_size, images, tags, purchases } = formState;
+
+    const updatedPost = {
+      content,
+      upload_place: address,
+      body_size,
+      images,
+      tags,
+    };
+
+    // 게시글 업데이트
+    const { error: postError } = await supabase
+      .from("posts")
+      .update(updatedPost)
+      .eq("id", id);
+
+    if (postError) throw postError;
+
+    // 기존 구매 데이터 삭제
+    const { error: deleteError } = await supabase
+      .from("purchase")
+      .delete()
+      .eq("post_id", id);
+
+    if (deleteError) throw deleteError;
+
+    // 새 구매 데이터 삽입
+    if (purchases.length > 0) {
+      const purchaseData = purchases.map((purchase) => ({
+        ...purchase,
+        post_id: id,
+      }));
+
+      const { error: purchaseError } = await supabase
+        .from("purchase")
+        .insert(purchaseData);
+
+      if (purchaseError) throw purchaseError;
+    }
+  };
+
+  return useMutation<void, Error, void>({
+    mutationFn, // 분리된 mutationFn 전달
+    ...options, // 추가 옵션 전달
+  });
+};

--- a/src/lib/hooks/write/usePostQueries.ts
+++ b/src/lib/hooks/write/usePostQueries.ts
@@ -1,8 +1,6 @@
-// useEditPostQuery와 useUpdatePostMutation 훅 구현
-
-import { useQuery, useMutation, UseMutationOptions, UseQueryOptions } from "@tanstack/react-query";
-import { createClient } from "@/lib/utils/supabase/client";
 import type { Database } from "@/lib/types/supabase";
+import { createClient } from "@/lib/utils/supabase/client";
+import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from "@tanstack/react-query";
 
 const supabase = createClient();
 
@@ -22,38 +20,34 @@ export const useEditPostQuery = (
   >({
     queryKey: ["post", id],
     queryFn: async () => {
-      const { data: postData, error: postError } = await supabase
-        .from("posts")
-        .select("*")
-        .eq("id", id)
-        .single();
-    
+      const { data: postData, error: postError } = await supabase.from("posts").select("*").eq("id", id).single();
+
       console.log("Fetched postData:", postData); // 디버깅 로그 추가
-    
+
       if (postError) {
         console.error("Post fetch error:", postError);
         throw postError;
       }
-    
+
       const { data: purchaseData, error: purchaseError } = await supabase
         .from("purchase")
         .select("*")
         .eq("post_id", id);
-    
+
       console.log("Fetched purchaseData:", purchaseData); // 디버깅 로그 추가
-    
+
       if (purchaseError) {
         console.error("Purchase fetch error:", purchaseError);
         throw purchaseError;
       }
-    
+
       return {
         post: postData,
-        purchases: purchaseData || [],
+        purchases: purchaseData || []
       };
     },
     staleTime: 60000, // 1분 동안 캐싱
-    onSuccess, // 옵션 객체의 일부로 포함
+    onSuccess // 옵션 객체의 일부로 포함
   } as UseQueryOptions<
     {
       post: Database["public"]["Tables"]["posts"]["Row"];
@@ -84,22 +78,16 @@ export const useUpdatePostMutation = (
       upload_place: address,
       body_size,
       images,
-      tags,
+      tags
     };
 
     // 게시글 업데이트
-    const { error: postError } = await supabase
-      .from("posts")
-      .update(updatedPost)
-      .eq("id", id);
+    const { error: postError } = await supabase.from("posts").update(updatedPost).eq("id", id);
 
     if (postError) throw postError;
 
     // 기존 구매 데이터 삭제
-    const { error: deleteError } = await supabase
-      .from("purchase")
-      .delete()
-      .eq("post_id", id);
+    const { error: deleteError } = await supabase.from("purchase").delete().eq("post_id", id);
 
     if (deleteError) throw deleteError;
 
@@ -107,12 +95,10 @@ export const useUpdatePostMutation = (
     if (purchases.length > 0) {
       const purchaseData = purchases.map((purchase) => ({
         ...purchase,
-        post_id: id,
+        post_id: id
       }));
 
-      const { error: purchaseError } = await supabase
-        .from("purchase")
-        .insert(purchaseData);
+      const { error: purchaseError } = await supabase.from("purchase").insert(purchaseData);
 
       if (purchaseError) throw purchaseError;
     }
@@ -120,6 +106,6 @@ export const useUpdatePostMutation = (
 
   return useMutation<void, Error, void>({
     mutationFn, // 분리된 mutationFn 전달
-    ...options, // 추가 옵션 전달
+    ...options // 추가 옵션 전달
   });
 };


### PR DESCRIPTION
## Title

- feat: 새벽감성 수정페이지 구현

## Changes

- src/app/write/[id]/page.tsx
- src/app/write/_components/ContentSection.tsx
- src/app/write/page.tsx
- src/lib/hooks/write/useFormHanlders.ts
- src/lib/hooks/write/usePostQueries.ts


## PR 생성 날짜

- 2025.1.19

## CheckList

- 마참내! 수정페이지 구현 완료! (경로는 write/[posts의 id]로 구현)
- 줄바꿈.. 적용을 위한 안내 (src/app/detail/_components/ContentsSection.tsx)
적용시켰다가, 혹시 모를 충돌을 위해 다시 되돌려놨습니다. 슬랙에도 남겨놨지만.. 나중에 한번 수정해주시면 감사하겠습니다 ^-^)b
```
{/* 엄정은이 추가하라고 해서 추가한 줄바꿈.. 기능추가 ^-^)b */}
<p className="mt-6 h-[8.5rem] overflow-auto text-title2 font-medium whitespace-pre-wrap">{content}</p>
```

#### 이제 림졍은 모달.. 수정하러갑니다.. 총총총...
