### PR TITLE
refactor: 블러이미지 추가

### DIFF
--- a/src/app/write/_components/ImageUploadSection.tsx
+++ b/src/app/write/_components/ImageUploadSection.tsx
@@ -51,7 +51,7 @@ function ImageUploadSection({ images, setImages, blur, setBlur }: ImageUploadSec
       }
 
       // Canvas 크기 설정 (아주 작은 크기로 축소)
-      const width = 10; // 축소된 너비
+      const width = 3; // 축소된 너비
       const height = (imageBitmap.height / imageBitmap.width) * width; // 비율 유지
 
       canvas.width = width;

--- a/src/components/shared/CardPost.tsx
+++ b/src/components/shared/CardPost.tsx
@@ -16,7 +16,14 @@ const Cardpost = ({ post, isMasonry }: Props) => {
     <div className={clsx("masonry-post group relative overflow-hidden rounded-2xl", isMasonry || "aspect-square")}>
       <Link href={`/detail/${post.id}/view`} className="click-box z-20"></Link>
       <figure className="relative h-full w-full">
-        <Image src={post.images[0]} alt={post.content} {...imageProps} className="object-cover object-center" />
+        <Image
+          src={post.images[0]}
+          alt={post.content}
+          {...imageProps}
+          className="object-cover object-center"
+          placeholder="blur"
+          blurDataURL={post.thumbnail_blur_url}
+        />
       </figure>
       <div className="click-box bg-black p-4 text-white opacity-0 transition-all duration-300 group-hover:bg-opacity-50 group-hover:opacity-100">
         <div className="absolute right-4 top-4 z-20">

--- a/src/components/shared/GridPost.tsx
+++ b/src/components/shared/GridPost.tsx
@@ -12,7 +12,13 @@ const GridPost = ({ post }: Props) => {
     <li key={post.id} className="relative mb-4">
       <Link href={`/detail/${post.id}/view`} className="click-box z-10"></Link>
       <figure className="thumbnail aspect-square rounded-2xl">
-        <Image src={post.images[0]} alt={post.content} fill={true} />
+        <Image
+          src={post.images[0]}
+          alt={post.content}
+          fill={true}
+          placeholder="blur"
+          blurDataURL={post.thumbnail_blur_url}
+        />
       </figure>
 
       <p className="ellip2 mt-4 text-title2 font-medium">{post.content}</p>

--- a/src/components/shared/ListPost.tsx
+++ b/src/components/shared/ListPost.tsx
@@ -16,7 +16,13 @@ const Listpost = ({ post }: Props) => {
     <li className="relative mb-6 flex gap-6 py-4">
       <Link href={`/detail/${post.id}/view`} className="click-box z-10"></Link>
       <figure className="thumbnail h-[11.25rem] w-[11.25rem] rounded-2xl bg-gray-200">
-        <Image src={post.images[0]} alt={post.content} fill={true} />
+        <Image
+          src={post.images[0]}
+          alt={post.content}
+          fill={true}
+          placeholder="blur"
+          blurDataURL={post.thumbnail_blur_url}
+        />
       </figure>
 
       <div className="relative w-[calc(100%-12.75rem)]">

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -279,7 +279,7 @@ export type Database = {
           is_saved: boolean
           likes: number
           tags: string[]
-          thumbnail_blur_url: string | null
+          thumbnail_blur_url: string
           upload_place: string | null
           user_id: string
           view: number
@@ -294,7 +294,7 @@ export type Database = {
           is_saved?: boolean
           likes: number
           tags: string[]
-          thumbnail_blur_url?: string | null
+          thumbnail_blur_url: string
           upload_place?: string | null
           user_id: string
           view: number
@@ -309,7 +309,7 @@ export type Database = {
           is_saved?: boolean
           likes?: number
           tags?: string[]
-          thumbnail_blur_url?: string | null
+          thumbnail_blur_url?: string
           upload_place?: string | null
           user_id?: string
           view?: number
@@ -368,6 +368,7 @@ export type Database = {
           introduction: string
           is_verified: boolean
           nickname: string
+          onboard: boolean
           profile_image: string | null
         }
         Insert: {
@@ -378,6 +379,7 @@ export type Database = {
           introduction?: string
           is_verified?: boolean
           nickname: string
+          onboard?: boolean
           profile_image?: string | null
         }
         Update: {
@@ -388,6 +390,7 @@ export type Database = {
           introduction?: string
           is_verified?: boolean
           nickname?: string
+          onboard?: boolean
           profile_image?: string | null
         }
         Relationships: []


### PR DESCRIPTION
## Title

- 블러이미지 추가

## Changes

- src/app/write/_components/ImageUploadSection.tsx
- src/components/shared/CardPost.tsx
- src/components/shared/GridPost.tsx
- src/components/shared/ListPost.tsx

## PR 생성 날짜

- 2025.01.19

## CheckList

- next image의 로딩 최적화 기능을 활용하여 리스트 이미지가 로딩되기 전에 블러이미지가 보입니다
