### PR TITLE
refactor: useActiveTabs를 공용 훅으로 재정의

### DIFF
--- a/src/app/bookmark/_components/TabContents.tsx
+++ b/src/app/bookmark/_components/TabContents.tsx
@@ -5,7 +5,7 @@ import BookmarkList from "../_components/BookmarkList";
 import LikedPostList from "../_components/LikedPostList";
 
 const TabContents = () => {
-  const { activeTab, handleTabChange } = useActiveTabs(2);
+  const { activeTab, handleTabChange } = useActiveTabs();
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="h-14 w-full">
       <TabsList className="h-full w-full justify-start rounded-none border-t bg-transparent p-0">

--- a/src/app/bookmark/_components/TabContents.tsx
+++ b/src/app/bookmark/_components/TabContents.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
-import { useActiveTabs } from "@/lib/hooks/mypage/useActiveTabs";
+import { useActiveTabs } from "@/lib/hooks/common/useActiveTabs";
 import BookmarkList from "../_components/BookmarkList";
 import LikedPostList from "../_components/LikedPostList";
 
 const TabContents = () => {
-  const { activeTab, handleTabChange } = useActiveTabs();
+  const { activeTab, handleTabChange } = useActiveTabs(2);
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="h-14 w-full">
       <TabsList className="h-full w-full justify-start rounded-none border-t bg-transparent p-0">

--- a/src/app/mypage/_components/MypageMenu.tsx
+++ b/src/app/mypage/_components/MypageMenu.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
-import { useActiveTabs } from "@/lib/hooks/mypage/useActiveTabs";
+import { MYPAGE_MENU } from "@/lib/constants/constants";
+import { useActiveTabs } from "@/lib/hooks/common/useActiveTabs";
 import AccountSettingTabs from "./AccountSettingTabs";
 import MyPosts from "./MyPosts";
 import RecentViewPosts from "./RecentViewPosts";
 import VerificationSection from "./VerificationSection";
-import { MYPAGE_MENU } from "@/lib/constants/constants";
 
 const MypageMenu = () => {
-  const { activeTab, handleTabChange } = useActiveTabs();
+  const { activeTab, handleTabChange } = useActiveTabs(4);
 
   return (
     <div className="container mx-auto max-w-7xl">

--- a/src/lib/hooks/common/useActiveTabs.ts
+++ b/src/lib/hooks/common/useActiveTabs.ts
@@ -1,7 +1,15 @@
-import { MYPAGE_MENU } from "@/lib/constants/constants";
 import { useEffect, useState } from "react";
 
-export const useActiveTabs = () => {
+/**
+ * 활성화된 탭으로 새로고침 후에도 보여주는 hook
+ * 매개변수로 사용할 총 탭의 숫자를 넘겨주면 됩니다.
+ *
+ * 반환값(return)
+ * activeTab [string]: 현재 활성화 된 탭
+ * handleTabChange [(value: string) => void]: 활성화 탭의 URL을 업데이트 하는 함수
+ */
+
+export const useActiveTabs = (numberOfTabs: number) => {
   // 빈 탭으로 초기화
   const [activeTab, setActiveTab] = useState("");
 
@@ -12,7 +20,7 @@ export const useActiveTabs = () => {
     const tabParam = params.get("tab");
 
     // 해당 tab query가 있는 경우에만 활성화 탭 세팅
-    if (tabParam && MYPAGE_MENU.some((_, index) => `tab-${index}` === tabParam)) {
+    if (tabParam && isValidTab(tabParam, numberOfTabs)) {
       setActiveTab(tabParam);
     } else {
       // tab이 없는 경우 첫번째 탭 활성화
@@ -29,6 +37,17 @@ export const useActiveTabs = () => {
     params.set("tab", value);
     const newUrl = `${window.location.pathname}?${params.toString()}`;
     window.history.replaceState({}, "", newUrl);
+  };
+
+  // 탭 범위 체크
+  const isValidTab = (tabParam: string, numberOfTabs: number) => {
+    // "tab-{index}"와 범위에 맞는지 확인
+    const regex = /^tab-(\d+)$/;
+    const match = tabParam.match(regex);
+    if (!match) return false;
+
+    const index = parseInt(match[1], 10);
+    return index >= 0 && index < numberOfTabs;
   };
 
   return {

--- a/src/lib/hooks/common/useActiveTabs.ts
+++ b/src/lib/hooks/common/useActiveTabs.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
  * handleTabChange [(value: string) => void]: 활성화 탭의 URL을 업데이트 하는 함수
  */
 
-export const useActiveTabs = (numberOfTabs: number) => {
+export const useActiveTabs = (numberOfTabs: number = 5) => {
   // 빈 탭으로 초기화
   const [activeTab, setActiveTab] = useState("");
 


### PR DESCRIPTION
## Title

- refactor: useActiveTabs를 공용 훅으로 재정의

## Changes

- useActiveTabs.ts
위치를 옮겨서 해당 훅을 사용하는 import의 위치도 바뀌었습니다.

## PR 생성 날짜

- 2025.01.22

## CheckList

- [x] 주석 정리
