### PR TITLE
feat: 태그 필터 목록을 태그 그룹별로 분리

### DIFF
--- a/src/app/search/_components/SearchContents.tsx
+++ b/src/app/search/_components/SearchContents.tsx
@@ -1,22 +1,37 @@
 "use client";
 import ErrorScreen from "@/components/common/ErrorScreen";
+import LoadingSpinner from "@/components/shared/LoadingSpinner";
 import { useSearchPosts } from "@/lib/hooks/search/useSearchPosts";
 import { useSearchQuery } from "@/lib/hooks/search/useSearchQuery";
+import useCategoryStore from "@/lib/store/useCategoryStore";
+import { useEffect, useState } from "react";
 import Pagination from "./Pagination";
 import SearchResults from "./SearchResults";
 import SortPosts from "./SortPosts";
 import TagFilters from "./TagFilters";
 
 const SearchContents = () => {
+  const { selectedCategory, isHydrated } = useCategoryStore();
+  const [readyToRender, setReadyToRender] = useState(false);
   const { query, page, tags, sort, handleSort } = useSearchQuery();
   const { Results, isPending, isError } = useSearchPosts(query, page, Object.values(tags).flat(), sort);
+
+  useEffect(() => {
+    if (isHydrated) {
+      setReadyToRender(true);
+    }
+  }, [isHydrated]);
+
+  if (!readyToRender) {
+    return <LoadingSpinner />;
+  }
 
   if (isError) return <ErrorScreen error={new Error("검색 데이터를 불러오는 중 에러가 발생했습니다.")} />;
 
   return (
     <>
       <section>
-        <TagFilters />
+        <TagFilters selectedGroup={selectedCategory} />
       </section>
       <SortPosts sort={sort} handleSort={handleSort} />
       <section className="mt-10">

--- a/src/app/search/_components/SearchContents.tsx
+++ b/src/app/search/_components/SearchContents.tsx
@@ -1,13 +1,16 @@
 "use client";
 import ErrorScreen from "@/components/common/ErrorScreen";
 import LoadingSpinner from "@/components/shared/LoadingSpinner";
+import SlideOver from "@/components/ui/SlideOver";
 import { useSearchPosts } from "@/lib/hooks/search/useSearchPosts";
 import { useSearchQuery } from "@/lib/hooks/search/useSearchQuery";
 import useCategoryStore from "@/lib/store/useCategoryStore";
+import { SlidersHorizontal } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import Pagination from "./Pagination";
 import SearchResults from "./SearchResults";
 import SortPosts from "./SortPosts";
+import TagCheckFilters from "./TagCheckFilters";
 import TagFilters from "./TagFilters";
 
 const SearchContents = () => {
@@ -15,6 +18,7 @@ const SearchContents = () => {
   const [readyToRender, setReadyToRender] = useState(false);
   const { query, page, tags, sort, handleSort } = useSearchQuery();
   const { Results, isPending, isError } = useSearchPosts(query, page, Object.values(tags).flat(), sort);
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     if (isHydrated) {
@@ -33,11 +37,27 @@ const SearchContents = () => {
       <section>
         <TagFilters selectedGroup={selectedCategory} />
       </section>
-      <SortPosts sort={sort} handleSort={handleSort} />
-      <section className="mt-10">
+
+      <div className="relative mb-10 flex items-center justify-end mb:mb-0 mb:h-[48px] mb:justify-between">
+        <button
+          onClick={() => setIsOpen(true)}
+          className="hidden h-[24px] w-[24px] items-center justify-center text-text-03 mb:flex"
+        >
+          <SlidersHorizontal size={16} weight="fill" />
+        </button>
+        <SortPosts sort={sort} handleSort={handleSort} />
+      </div>
+
+      <section>
         <SearchResults Results={Results} isPending={isPending} />
       </section>
       <Pagination Results={Results} />
+
+      {isOpen && (
+        <SlideOver title="필터" onClose={() => setIsOpen(false)}>
+          <TagCheckFilters selectedGroup={selectedCategory} />
+        </SlideOver>
+      )}
     </>
   );
 };

--- a/src/app/search/_components/SortPosts.tsx
+++ b/src/app/search/_components/SortPosts.tsx
@@ -16,10 +16,10 @@ type Props = {
 
 const SortPosts = ({ sort, handleSort }: Props) => {
   return (
-    <div className="relative flex justify-end">
+    <>
       <Dropdown
         trigger={
-          <div className="flex h-8 items-center gap-3 font-medium leading-8">
+          <div className="flex h-8 items-center gap-3 font-medium leading-8 mb:gap-2 mb:text-caption mb:text-text-03">
             {sortOptions.find((option) => option.key === sort)?.label || "선택"}
             <CaretDown weight="fill" />
           </div>
@@ -30,7 +30,7 @@ const SortPosts = ({ sort, handleSort }: Props) => {
           {sortOptions.map((option) => (
             <li
               key={option.key}
-              className="w-full whitespace-nowrap py-2 text-left font-medium transition duration-300 hover:text-primary-default"
+              className="w-full whitespace-nowrap py-2 text-left font-medium transition duration-300 hover:text-primary-default mb:text-caption"
             >
               <button
                 onClick={() => {
@@ -43,7 +43,7 @@ const SortPosts = ({ sort, handleSort }: Props) => {
           ))}
         </ul>
       </Dropdown>
-    </div>
+    </>
   );
 };
 

--- a/src/app/search/_components/TagCheckFilters.tsx
+++ b/src/app/search/_components/TagCheckFilters.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { TAG_GROUPS } from "@/lib/constants/constants";
+import { useSearchQuery } from "@/lib/hooks/search/useSearchQuery";
+import { X } from "@phosphor-icons/react";
+
+type TagCheckFiltersProps = {
+  selectedGroup: string | null;
+};
+
+const TagCheckFilters = ({ selectedGroup }: TagCheckFiltersProps) => {
+  const { tags, handleToggleTag } = useSearchQuery();
+
+  // 선택된 태그
+  const selectedTags = Object.entries(tags).flatMap(([groupKey, groupTags]) =>
+    groupTags.map((tag) => ({ groupKey, tag }))
+  );
+
+  return (
+    <>
+      {/* 선택된 태그 표시 */}
+      <div className="bg-bg-02">
+        {selectedTags.length > 0 && (
+          <div className="inner flex flex-wrap gap-3 py-[12px] text-caption font-medium text-text-03">
+            {selectedTags.map(({ groupKey, tag }) => (
+              <div key={tag} className="flex items-center gap-1">
+                <span>{tag}</span>
+                <button onClick={() => handleToggleTag(groupKey, tag)}>
+                  <X />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 태그 필터 UI */}
+      {TAG_GROUPS.filter((group) => !selectedGroup || group.key === selectedGroup).map((group) => (
+        <div key={group.key} className="inner flex max-h-[50vh] flex-col flex-wrap gap-4 py-4 text-caption">
+          {group.tags.map((tag) => (
+            <label key={tag} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={tags[group.key]?.includes(tag) || false}
+                onChange={() => handleToggleTag(group.key, tag)}
+                className="h-[16px] w-[16px] rounded-[4px] accent-primary-default opacity-40 checked:opacity-100"
+              />
+              <span className="text-sm">{tag}</span>
+            </label>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default TagCheckFilters;

--- a/src/app/search/_components/TagFilters.tsx
+++ b/src/app/search/_components/TagFilters.tsx
@@ -3,14 +3,19 @@ import { Tags } from "@/components/ui/Tags";
 import { TAG_GROUPS } from "@/lib/constants/constants";
 import { useSearchQuery } from "@/lib/hooks/search/useSearchQuery";
 
-const TagFilters = () => {
+type TagFiltersProps = {
+  selectedGroup: string | null;
+};
+
+const TagFilters = ({ selectedGroup }: TagFiltersProps) => {
   const { tags, handleToggleTag } = useSearchQuery();
 
   return (
-    <div className="mb-4">
-      {TAG_GROUPS.map((group) => (
+    <>
+      {TAG_GROUPS.filter((group) => !selectedGroup || group.key === selectedGroup).map((group) => (
         <div key={group.key} className="mb-6">
-          <p className="mb-2 text-[18px] font-bold">{group.title}</p>
+          <h2 className="mb-6 text-title1 font-bold">{group.title}</h2>
+
           <div className="flex flex-wrap gap-2">
             {group.tags.map((tag) => (
               <button key={tag} onClick={() => handleToggleTag(group.key, tag)}>
@@ -20,7 +25,7 @@ const TagFilters = () => {
           </div>
         </div>
       ))}
-    </div>
+    </>
   );
 };
 

--- a/src/app/search/_components/TagFilters.tsx
+++ b/src/app/search/_components/TagFilters.tsx
@@ -13,10 +13,10 @@ const TagFilters = ({ selectedGroup }: TagFiltersProps) => {
   return (
     <>
       {TAG_GROUPS.filter((group) => !selectedGroup || group.key === selectedGroup).map((group) => (
-        <div key={group.key} className="mb-6">
-          <h2 className="mb-6 text-title1 font-bold">{group.title}</h2>
+        <div key={group.key}>
+          <h2 className="mb-6 text-title1 font-bold mb:mb-0 mb:text-title2">{group.title}</h2>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="mb-6 flex flex-wrap gap-2 mb:hidden">
             {group.tags.map((tag) => (
               <button key={tag} onClick={() => handleToggleTag(group.key, tag)}>
                 <Tags label={tag} variant={`${tags[group.key]?.includes(tag) ? "black" : "gray"}`} />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,7 +3,8 @@ import SearchContents from "./_components/SearchContents";
 
 const SearchPage = () => {
   return (
-    <div className="inner pb-40 tb:pb-10">
+    <div className="inner pb-40 pt-10 tb:pb-10">
+      <div className="absolute left-0 top-20 z-50 h-2 w-full bg-bg-01"></div>
       <Suspense fallback={<p></p>}>
         <SearchContents />
       </Suspense>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,7 +4,7 @@ import SearchContents from "./_components/SearchContents";
 const SearchPage = () => {
   return (
     <div className="inner pb-40 pt-10 tb:pb-10">
-      <div className="absolute left-0 top-20 z-50 h-2 w-full bg-bg-01"></div>
+      <div className="absolute left-0 top-20 z-50 h-2 w-full bg-bg-01 mb:hidden"></div>
       <Suspense fallback={<p></p>}>
         <SearchContents />
       </Suspense>

--- a/src/components/layout/HeaderCategorys.tsx
+++ b/src/components/layout/HeaderCategorys.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { REGIONS, TAG_GROUPS } from "@/lib/constants/constants";
 import { useSearchQuery } from "@/lib/hooks/search/useSearchQuery";
+import useCategoryStore from "@/lib/store/useCategoryStore";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -12,6 +13,7 @@ type Props = {
 const HeaderCategorys = ({ handleClose }: Props) => {
   const [tags, setTags] = useState<Tags>({});
   const router = useRouter();
+  const setSelectedCategory = useCategoryStore((state) => state.setSelectedCategory);
   const { handleToggleTag, encodeTagsForUrl } = useSearchQuery();
 
   const handleCategoryClick = (key: string, tag: string) => {
@@ -24,11 +26,13 @@ const HeaderCategorys = ({ handleClose }: Props) => {
     params.set("page", "1");
     params.set("category", encodeTagsForUrl(updatedTags));
 
+    setSelectedCategory(key);
+
     router.push(`/search?${params.toString()}`);
   };
 
   return (
-    <div className="mx-auto flex max-w-[1200px] pb-8 pt-4">
+    <>
       {TAG_GROUPS.map((group) => (
         <div key={group.key} className="text-title2">
           <p className="mb-8 font-bold">{group.title}</p>
@@ -61,7 +65,7 @@ const HeaderCategorys = ({ handleClose }: Props) => {
           ))}
         </ul>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -7,7 +7,7 @@ import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "../ui/Button";
 import HeaderCategorys from "./HeaderCategorys";
 import SearchBar from "./SearchBar";
@@ -18,6 +18,7 @@ const HeaderContent = () => {
   const { user } = useAuthStore();
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const toggleOpen = () => {
     setIsOpen((prev) => !prev);
@@ -106,15 +107,14 @@ const HeaderContent = () => {
       </div>
 
       <div
-        className={clsx(
-          "absolute left-0 top-full z-10 w-full overflow-hidden bg-bg-01 shadow-sm transition-all duration-300 ease-in-out",
-          {
-            "max-h-[600px]": isOpen,
-            "max-h-0": !isOpen
-          }
-        )}
+        className="absolute left-0 top-full z-10 w-full overflow-hidden bg-bg-01 shadow-sm transition-all duration-300 ease-in-out"
+        style={{
+          height: isOpen ? `${contentRef.current?.scrollHeight}px` : "0px"
+        }}
       >
-        <HeaderCategorys handleClose={handleClose} />
+        <div ref={contentRef} className="mx-auto flex max-w-[1200px] pb-8 pt-4">
+          <HeaderCategorys handleClose={handleClose} />
+        </div>
       </div>
       {isOpen && (
         <div

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -6,7 +6,7 @@ import NavItem from "./NavItem";
 
 const NavBar = () => {
   return (
-    <nav className="fixed bottom-0 z-50 hidden w-full bg-bg-01 pb-7 text-small text-text-02 tb:block">
+    <nav className="fixed bottom-0 z-40 hidden w-full bg-bg-01 pb-7 text-small text-text-02 tb:block">
       <ul className="flex justify-between">
         <NavItem href="/home" icon={<House weight="fill" size={24} />} label="홈" />
         <NavItem href="/search" icon={<MagnifyingGlass size={24} />} label="검색" />

--- a/src/components/shared/CardPost.tsx
+++ b/src/components/shared/CardPost.tsx
@@ -15,7 +15,12 @@ const Cardpost = ({ post, isMasonry }: Props) => {
   const [isImgError, setIsImgError] = useState<boolean>(false);
   const imageProps = isMasonry ? { width: 500, height: 700 } : { fill: true };
   return (
-    <div className={clsx("masonry-post group relative overflow-hidden rounded-2xl", isMasonry || "aspect-square")}>
+    <div
+      className={clsx(
+        "masonry-post group relative overflow-hidden rounded-2xl mb:rounded-lg",
+        isMasonry || "aspect-square"
+      )}
+    >
       <Link href={`/detail/${post.id}/view`} className="click-box z-20"></Link>
       <figure className="relative h-full w-full">
         <Image

--- a/src/components/shared/GridPost.tsx
+++ b/src/components/shared/GridPost.tsx
@@ -14,7 +14,7 @@ const GridPost = ({ post }: Props) => {
   return (
     <li key={post.id} className="relative mb-4">
       <Link href={`/detail/${post.id}/view`} className="click-box z-10"></Link>
-      <figure className="thumbnail aspect-square rounded-2xl">
+      <figure className="thumbnail aspect-square rounded-2xl mb:rounded-lg">
         <Image
           src={isImgError ? sampleImage : post.images[0]}
           alt={post.content}

--- a/src/components/ui/SlideOver.tsx
+++ b/src/components/ui/SlideOver.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { X } from "@phosphor-icons/react";
+import clsx from "clsx";
+import { ReactNode, useEffect, useRef, useState } from "react";
+
+type SlideOverProps = {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+};
+
+const SlideOver = ({ title, children, onClose }: SlideOverProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  // Prevent body scrolling
+  const bodyRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    bodyRef.current = document.body;
+
+    if (isVisible && bodyRef.current) {
+      bodyRef.current.style.overflow = "hidden";
+    } else if (bodyRef.current) {
+      bodyRef.current.style.overflow = "";
+    }
+
+    return () => {
+      if (bodyRef.current) {
+        bodyRef.current.style.overflow = "";
+      }
+    };
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(() => onClose(), 300); // Match the animation duration
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end">
+      <div
+        className={clsx(
+          "fixed inset-0 z-10 transition-all duration-300",
+          isVisible ? "animate-fadeIn bg-black bg-opacity-50" : "animate-fadeOut"
+        )}
+        onClick={handleClose}
+      ></div>
+
+      <div
+        className={clsx(
+          "z-[100] w-full rounded-t-2xl bg-white pb-[35px] shadow-lg transition-transform duration-300",
+          isVisible ? "animate-slideIn" : "animate-slideOut"
+        )}
+      >
+        <div className="inner flex h-[55px] items-center justify-between">
+          <p className="text-body font-medium">{title}</p>
+          <button className="text-text-03" onClick={handleClose}>
+            <X size={16} weight="bold" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SlideOver;

--- a/src/lib/store/useCategoryStore.ts
+++ b/src/lib/store/useCategoryStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type CategoryState = {
+  selectedCategory: string | null; // 선택된 카테고리
+  isHydrated: boolean; // 새로고침 시 상태 복원이 완료되었는지 확인
+  setSelectedCategory: (category: string | null) => void; // 카테고리 설정 함수
+};
+
+const useCategoryStore = create<CategoryState>()(
+  persist(
+    (set) => ({
+      selectedCategory: null,
+      isHydrated: false, // 초기값: 상태 복원 전
+      setSelectedCategory: (category) => set({ selectedCategory: category }) // 카테고리 설정 함수
+    }),
+    {
+      name: "selected-category",
+      onRehydrateStorage: (state) => {
+        if (state) {
+          // 복원이 완료되었음을 설정
+          state.isHydrated = true;
+        }
+      }
+    }
+  )
+);
+
+export default useCategoryStore;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -153,6 +153,14 @@ const config: Config = {
           from: { transform: "scale(1)" },
           to: { transform: "scale(0.95)" }
         },
+        slideIn: {
+          "0%": { transform: "translateY(100%)" },
+          "100%": { transform: "translateY(0)" }
+        },
+        slideOut: {
+          "0%": { transform: "translateY(0)" },
+          "100%": { transform: "translateY(100%)" }
+        },
         gradient: {
           "0%": { backgroundPosition: "0% 50%" },
           "50%": { backgroundPosition: "100% 50%" },
@@ -164,7 +172,9 @@ const config: Config = {
         fadeIn: "fadeIn 0.3s ease-out",
         fadeOut: "fadeOut 0.3s ease-out",
         scaleUp: "scaleUp 0.3s ease-out",
-        scaleDown: "scaleDown 0.3s ease-out"
+        scaleDown: "scaleDown 0.3s ease-out",
+        slideIn: "slideIn 0.3s ease-in-out",
+        slideOut: "slideOut 0.3s ease-in-out"
       },
       screens: {
         lt: { max: "1200px" }, // 일반 노트북 크기
@@ -172,6 +182,13 @@ const config: Config = {
         mb: { max: "480px" }, // 가장 큰 폰 크기
         mn: { max: "375px" } // 우리 모바일 디자인 시안 크기
       }
+    }
+  },
+  variants: {
+    extend: {
+      backgroundColor: ["checked"], // checked 상태에서 배경색 활성화
+      borderColor: ["checked"], // checked 상태에서 테두리색 활성화
+      textColor: ["checked"] // checked 상태에서 텍스트 색상 활성화
     }
   },
   plugins: [


### PR DESCRIPTION
## Title

- 태그 필터 목록을 태그 그룹별로 분리

## Changes

- 디자인 시안 대로 헤더 카테고리에서 특정 태그를 선택 시, search페이지에서 해당 태그그룹만 렌더링 되도록 구현했습니다

## PR 생성 날짜

- 2025.01.22

## CheckList

- + 모바일 화면에서의 태그 필터기능을 구현했습니다
