### PR TITLE
 refactor: 지역별 옷차림 리스트는 태그가 아닌 주소 표시

### DIFF
--- a/src/app/detail/_components/ButtonLike.tsx
+++ b/src/app/detail/_components/ButtonLike.tsx
@@ -27,7 +27,7 @@ const LikeButton = ({ postId, styleType = "masonry", iconSize, iconWeight = "fil
   const buttonClass = cn("flex justify-center items-center text-text-02 transition-color duration-300", {
     "text-primary-default": isLiked,
     "w-7 h-7 rounded-lg bg-bg-01": styleType === "masonry",
-    "gap-1": styleType === "list" || styleType === "detailMob",
+    "gap-2": styleType === "list" || styleType === "detailMob",
     "flex-col gap-2": styleType === "detail"
   });
 

--- a/src/app/search-location/_components/GridPostForLocation.tsx
+++ b/src/app/search-location/_components/GridPostForLocation.tsx
@@ -30,8 +30,8 @@ const GridPostForLocation = ({ post }: Props) => {
       </figure>
 
       <p className="ellip2 mt-4 text-title2 font-medium tb:mt-2 tb:text-body">{post.content}</p>
-      <p className="ellip1 mt-1 text-body text-text-03 tb:text-body">
-        <MapPinArea weight="fill" className="mr-1 inline-block text-primary-default" />
+      <p className="ellip1 mt-1 text-text-03 tb:mt-0 tb:text-caption">
+        <MapPinArea weight="fill" className="mr-1 inline-block text-primary-default mb:hidden" />
         {post.upload_place}
       </p>
     </li>

--- a/src/app/search-location/_components/GridPostForLocation.tsx
+++ b/src/app/search-location/_components/GridPostForLocation.tsx
@@ -1,0 +1,41 @@
+import sampleImage from "@/assets/images/image_sample.png";
+import useMediaQuery from "@/lib/hooks/common/useMediaQuery";
+import type { PostType } from "@/lib/types/post";
+import { MapPinArea } from "@phosphor-icons/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
+type Props = {
+  post: PostType;
+};
+
+const GridPostForLocation = ({ post }: Props) => {
+  const [isImgError, setIsImgError] = useState<boolean>(false);
+  const isTabletOrSmaller = useMediaQuery("(max-width: 768px)");
+
+  return (
+    <li key={post.id} className="relative mb-4">
+      <Link href={`/detail/${post.id}${isTabletOrSmaller ? "" : "/view"}`} className="click-box z-10"></Link>
+      <figure className="thumbnail aspect-square rounded-2xl mb:rounded-lg">
+        <Image
+          src={isImgError ? sampleImage : post.images[0]}
+          alt={post.content}
+          fill={true}
+          sizes="(max-width: 768px) 250px, 250px"
+          placeholder="blur"
+          blurDataURL={post.thumbnail_blur_url}
+          onError={() => setIsImgError(true)}
+        />
+      </figure>
+
+      <p className="ellip2 mt-4 text-title2 font-medium tb:mt-2 tb:text-body">{post.content}</p>
+      <p className="ellip1 mt-1 text-body text-text-03 tb:text-body">
+        <MapPinArea weight="fill" className="mr-1 inline-block text-primary-default" />
+        {post.upload_place}
+      </p>
+    </li>
+  );
+};
+
+export default GridPostForLocation;

--- a/src/app/search-location/_components/LocationContents.tsx
+++ b/src/app/search-location/_components/LocationContents.tsx
@@ -45,7 +45,7 @@ const LocationContents = () => {
       </div>
 
       <section>
-        <SearchResults Results={Results} isPending={isPending} />
+        <SearchResults Results={Results} isPending={isPending} isLocation={true} />
       </section>
       <Pagination Results={Results} page={page} handlePageChange={handlePageChange} />
 

--- a/src/app/search/_components/SearchResults.tsx
+++ b/src/app/search/_components/SearchResults.tsx
@@ -6,10 +6,10 @@ import type { PostType } from "@/lib/types/post";
 type SearchResultsProps = {
   Results: { items: PostType[]; total: number } | undefined;
   isPending: boolean;
-  isLocation: boolean;
+  isLocation?: boolean;
 };
 
-const SearchResults = ({ Results, isPending, isLocation }: SearchResultsProps) => {
+const SearchResults = ({ Results, isPending, isLocation = false }: SearchResultsProps) => {
   if (!Results || Results.items.length === 0)
     return <p className="mt-32 text-center text-subtitle font-medium text-text-02">검색 결과가 없습니다.</p>;
 

--- a/src/app/search/_components/SearchResults.tsx
+++ b/src/app/search/_components/SearchResults.tsx
@@ -1,3 +1,4 @@
+import GridPostForLocation from "@/app/search-location/_components/GridPostForLocation";
 import GridPost from "@/components/shared/GridPost";
 import GridSkeleton from "@/components/shared/GridSkeleton";
 import type { PostType } from "@/lib/types/post";
@@ -5,9 +6,10 @@ import type { PostType } from "@/lib/types/post";
 type SearchResultsProps = {
   Results: { items: PostType[]; total: number } | undefined;
   isPending: boolean;
+  isLocation: boolean;
 };
 
-const SearchResults = ({ Results, isPending }: SearchResultsProps) => {
+const SearchResults = ({ Results, isPending, isLocation }: SearchResultsProps) => {
   if (!Results || Results.items.length === 0)
     return <p className="mt-32 text-center text-subtitle font-medium text-text-02">검색 결과가 없습니다.</p>;
 
@@ -15,7 +17,9 @@ const SearchResults = ({ Results, isPending }: SearchResultsProps) => {
     <ul className="grid grid-cols-4 gap-6 tb:grid-cols-3 tb:gap-[12px] mb:grid-cols-2">
       {isPending
         ? [...Array(8)].map((_, index) => <GridSkeleton key={index} />)
-        : Results.items.map((post) => <GridPost key={post.id} post={post} />)}
+        : isLocation
+          ? Results.items.map((post) => <GridPostForLocation key={post.id} post={post} />)
+          : Results.items.map((post) => <GridPost key={post.id} post={post} />)}
     </ul>
   );
 };

--- a/src/components/common/Carousel.tsx
+++ b/src/components/common/Carousel.tsx
@@ -44,7 +44,10 @@ const Carousel = ({
         initialSlide={initialSlide}
         loop={loop}
         autoplay={autoplay}
-        navigation={navigation}
+        navigation={{
+          prevEl: ".prev",
+          nextEl: ".next"
+        }}
         pagination={pagination ? { clickable: true } : undefined}
         onSwiper={(swiperInstance) => {
           setSwiper(swiperInstance);
@@ -60,16 +63,18 @@ const Carousel = ({
       {arrow && (
         <>
           <button
-            className="slide-arrow prev absolute left-0 top-1/2 -translate-y-1/2 transform"
+            className="prev absolute left-10 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 transform items-center justify-center text-text-01 disabled:opacity-50"
             onClick={() => swiper?.slidePrev()}
+            disabled={swiper?.isBeginning}
           >
-            <CaretLeft />
+            <CaretLeft size={32} weight="bold" />
           </button>
           <button
-            className="slide-arrow next absolute right-0 top-1/2 -translate-y-1/2 transform"
+            className="next absolute right-10 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 transform items-center justify-center text-text-01 disabled:opacity-50"
             onClick={() => swiper?.slideNext()}
+            disabled={swiper?.isEnd}
           >
-            <CaretRight />
+            <CaretRight size={32} weight="bold" />
           </button>
         </>
       )}

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -46,7 +46,7 @@ const HeaderContent = () => {
             </h1>
           </Link>
 
-          <nav className="flex w-[22%] min-w-[190px] max-w-[16.5rem] justify-between text-title2 font-medium text-text-03">
+          <nav className="flex w-[22%] min-w-[190px] max-w-[16.5rem] justify-between text-title2 font-medium text-text-04">
             {!user ? (
               <button
                 onClick={() => {
@@ -68,7 +68,6 @@ const HeaderContent = () => {
               카테고리
               <CaretDown
                 size={20}
-                weight={isOpen ? "bold" : "regular"}
                 className={clsx({
                   "rotate-180": isOpen,
                   "rotate-0": !isOpen
@@ -84,7 +83,7 @@ const HeaderContent = () => {
               asChild
               variant="whiteLine"
               size="md"
-              className="infline-flex flex flex-row gap-2 py-3 text-body font-medium leading-[1.5rem]"
+              className="infline-flex flex flex-row gap-2 px-4 py-3 text-body font-medium leading-[1.5rem]"
             >
               {isLoading ? (
                 <div>

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -64,7 +64,7 @@ const HeaderContent = () => {
             <Link href="/chat" className="text-center">
               코칭
             </Link>
-            <button className={clsx("flex items-center gap-2", { "text-text-04": isOpen })} onClick={toggleOpen}>
+            <button className="flex items-center gap-2" onClick={toggleOpen}>
               카테고리
               <CaretDown
                 size={20}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -16,7 +16,7 @@ const NavBar = () => {
         <Suspense fallback={<p></p>}>
           <NavItem href="/home" location="/home" icon={<House weight="fill" size={24} />} label="홈" />
           <NavItem href="/search?popup=true" location="/search" icon={<MagnifyingGlass size={24} />} label="검색" />
-          <NavItem href="/chat" location="/chat" icon={<VideoCamera weight="fill" size={24} />} label="Live" />
+          <NavItem href="/chat" location="/chat" icon={<VideoCamera weight="fill" size={24} />} label="코칭" />
           <NavItem
             href="/bookmark"
             location="/bookmark"

--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -87,7 +87,7 @@ const SearchBar = () => {
           placeholder="어떤 룩을 찾으시나요?"
           value={inputValue}
           onChange={(e) => handleInputChange(e.target.value)}
-          className="h-12 w-full rounded-lg bg-transparent pl-14 pr-2 text-title2 font-medium outline-black placeholder:text-text-03 tb:h-[44px] tb:text-body tb:text-text-03"
+          className="h-12 w-full rounded-lg bg-transparent pl-14 pr-2 font-medium outline-black placeholder:text-text-03 tb:h-[44px] tb:text-body tb:text-text-03"
         />
         {showDropdown && (filteredTags.length > 0 || searchHistory.length > 0) && (
           <ul className="dropdown shadow-emphasize absolute left-0 top-[calc(100%+0.75rem)] z-50 w-full rounded-2xl bg-white p-6 tb:left-[-4.55%] tb:top-[calc(100%+17px)] tb:w-screen tb:rounded-none tb:p-0 tb:shadow-none">
@@ -110,7 +110,7 @@ const SearchBar = () => {
                 {searchHistory.map((query, index) => (
                   <li
                     key={index}
-                    className="tb:inner flex cursor-pointer justify-between py-2 text-title2 text-text-03 tb:h-[55px] tb:p-0 tb:text-body tb:font-medium"
+                    className="tb:inner flex cursor-pointer justify-between py-2 text-text-03 tb:h-[55px] tb:p-0 tb:text-body tb:font-medium"
                   >
                     <button onClick={() => handleSelectHistory(query)} className="ellip1 flex-1 text-left">
                       {query}
@@ -138,7 +138,7 @@ const SearchBar = () => {
                 {filteredTags.slice(0, 5).map((tag) => (
                   <li
                     key={tag}
-                    className="tb:inner flex cursor-pointer justify-between py-2 text-title2 text-text-03 tb:h-[55px] tb:p-0 tb:text-body tb:font-medium"
+                    className="tb:inner mt-2 flex cursor-pointer justify-between py-2 text-text-03 tb:h-[55px] tb:p-0 tb:text-body tb:font-medium"
                   >
                     <button
                       onClick={() => {

--- a/src/components/shared/ImageModal.tsx
+++ b/src/components/shared/ImageModal.tsx
@@ -2,6 +2,7 @@
 
 import Carousel from "@/components/common/Carousel";
 import ModalItem from "@/components/ui/Modal";
+import useMediaQuery from "@/lib/hooks/common/useMediaQuery";
 import { handleImageDownload } from "@/lib/utils/common/ImageDownload";
 import { DownloadSimple, X } from "@phosphor-icons/react";
 import { useRef, useState } from "react";
@@ -18,6 +19,7 @@ type ImageModalProps = {
 const ImageModal = ({ images, isOpen, onClose, selectedImage, isPagination = true }: ImageModalProps) => {
   const [currentImage, setCurrentImage] = useState(selectedImage);
   const swiperRef = useRef<SwiperClass | null>(null);
+  const isTabletOrSmaller = useMediaQuery("(max-width: 768px)");
 
   return (
     <ModalItem isOpen={isOpen} onClose={onClose} mode="imageView">
@@ -32,7 +34,7 @@ const ImageModal = ({ images, isOpen, onClose, selectedImage, isPagination = tru
             setCurrentImage(images[activeIndex]);
           }}
           initialSlide={images.indexOf(selectedImage)}
-          arrow={true}
+          arrow={isTabletOrSmaller ? false : true}
           pagination={isPagination}
         >
           {images.map((image, index) => (

--- a/src/components/shared/ImageModal.tsx
+++ b/src/components/shared/ImageModal.tsx
@@ -12,9 +12,10 @@ type ImageModalProps = {
   onClose: () => void;
   images: string[];
   selectedImage: string;
+  isPagination?: boolean;
 };
 
-const ImageModal = ({ images, isOpen, onClose, selectedImage }: ImageModalProps) => {
+const ImageModal = ({ images, isOpen, onClose, selectedImage, isPagination = true }: ImageModalProps) => {
   const [currentImage, setCurrentImage] = useState(selectedImage);
   const swiperRef = useRef<SwiperClass | null>(null);
 
@@ -31,7 +32,7 @@ const ImageModal = ({ images, isOpen, onClose, selectedImage }: ImageModalProps)
             setCurrentImage(images[activeIndex]);
           }}
           initialSlide={images.indexOf(selectedImage)}
-          pagination={true}
+          pagination={isPagination}
         >
           {images.map((image, index) => (
             <SwiperSlide key={index} className="relative h-screen w-fit self-center text-center">

--- a/src/components/shared/ImageModal.tsx
+++ b/src/components/shared/ImageModal.tsx
@@ -32,6 +32,7 @@ const ImageModal = ({ images, isOpen, onClose, selectedImage, isPagination = tru
             setCurrentImage(images[activeIndex]);
           }}
           initialSlide={images.indexOf(selectedImage)}
+          arrow={true}
           pagination={isPagination}
         >
           {images.map((image, index) => (

--- a/src/components/shared/ListPost.tsx
+++ b/src/components/shared/ListPost.tsx
@@ -69,7 +69,7 @@ const Listpost = ({ post }: Props) => {
         <div className="absolute bottom-0 left-0 flex gap-2 tb:relative tb:mt-1 tb:gap-1">
           {isTabletOrSmaller
             ? post.tags.slice(0, 3).map((tag) => <Tags key={tag} variant="gray" size="md" label={tag} />)
-            : post.tags.map((tag) => <Tags key={tag} variant="gray" size="md" label={tag} />)}
+            : post.tags.slice(0, 4).map((tag) => <Tags key={tag} variant="gray" size="md" label={tag} />)}
         </div>
       </div>
     </li>

--- a/src/components/shared/ListPost.tsx
+++ b/src/components/shared/ListPost.tsx
@@ -60,9 +60,8 @@ const Listpost = ({ post }: Props) => {
 
         <div className="absolute bottom-0 right-0 z-20 flex gap-4 text-title2 font-medium leading-7 text-text-03 tb:bottom-[7px] tb:left-0 tb:right-auto tb:text-body mb:text-caption">
           <LikeButton postId={post.id} styleType="list" iconSize={28} showNumber />
-          <span className="post-center pointer-events-none flex items-center gap-1">
+          <span className="post-center pointer-events-none flex items-center gap-2">
             <ChatCircleDots size={isTabletOrSmaller ? 16 : 28} className="text-text-02" weight="fill" />
-
             <span>{post.comments}</span>
           </span>
         </div>


### PR DESCRIPTION
## Title

-  지역별 옷차림 리스트는 태그가 아닌 주소 표시

## Changes

- 지역별 옷차림 리스트는 태그가 아닌 주소 표시
- nav bar line > 코칭 수정
- image modal 수정 : pagination props 옵션으로 변경, pc 에서 화살표 추가,
- 그 외 디자인 QA 완료

## PR 생성 날짜

- 2025.02.04

## CheckList

- 코칭 사진첩에서 imageModal 컴포넌트 사용하실때, isPagination={false} 로 바꾸시면 됩니다
