### PR TITLE
fix: 프로필 수정의 이미지 파일만 받도록 수정

### DIFF
--- a/src/app/mypage/profile-setting/_components/ProfileImageUploadSection.tsx
+++ b/src/app/mypage/profile-setting/_components/ProfileImageUploadSection.tsx
@@ -1,3 +1,5 @@
+import { ALLOWED_IMAGE_FILE_TYPES } from "@/lib/constants/constants";
+import { toast } from "@/lib/utils/common/toast";
 import Image from "next/image";
 import { ChangeEvent, Dispatch, DragEvent, SetStateAction } from "react";
 import CameraButton from "./CameraButton";
@@ -13,6 +15,11 @@ const ProfileImageUploadSection = ({ setImageFile, setImagePreview, imagePreview
   const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      if (!ALLOWED_IMAGE_FILE_TYPES.includes(file.type)) {
+        toast("PNG, JPG, JPEG, 그리고 GIF 파일만 첨부가 가능합니다.", "warning");
+        return;
+      }
+
       setImageFile(file);
       const reader = new FileReader();
       reader.onloadend = () => setImagePreview(reader.result as string);
@@ -25,6 +32,11 @@ const ProfileImageUploadSection = ({ setImageFile, setImagePreview, imagePreview
     e.preventDefault();
     const file = e.dataTransfer.files?.[0];
     if (file) {
+      if (!ALLOWED_IMAGE_FILE_TYPES.includes(file.type)) {
+        toast("PNG, JPG, JPEG, 그리고 GIF 파일만 첨부가 가능합니다.", "warning");
+        return;
+      }
+
       setImageFile(file);
       const reader = new FileReader();
       reader.onloadend = () => setImagePreview(reader.result as string);

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -2,6 +2,8 @@ export const POSTS_PER_PAGE = 8; // 페이지 당 게시물 개수
 
 export const VERIFICATION_THRESHOLD = 500; // 인증 유저 조건
 
+export const ALLOWED_IMAGE_FILE_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif"];
+
 // 태그 그룹 정의
 export const TAG_GROUPS = [
   { key: "gender", title: "성별", tags: ["남성", "여성", "성별무관"], max: 1 },


### PR DESCRIPTION
## Title

- fix: 프로필 수정의 이미지 파일만 받도록 수정

## Changes

- ProfileImageUploadSection.tsx
- constants.ts

## PR 생성 날짜

- 2025.02.07

## CheckList

- [x] 버그 픽스
